### PR TITLE
Enable switching between login and signup modals

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,13 +177,24 @@ export default function LandingPage() {
       </header>
 
       {/* Login Modal */}
-      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
+      <LoginModal
+        isOpen={isLoginModalOpen}
+        onClose={() => setIsLoginModalOpen(false)}
+        onOpenSignup={() => {
+          setIsLoginModalOpen(false)
+          setIsSignupModalOpen(true)
+        }}
+      />
 
       {/* Signup Modal */}
       <SignupModal
         isOpen={isSignupModalOpen}
         onClose={() => setIsSignupModalOpen(false)}
         onSignupSuccess={handleSignupSuccess}
+        onOpenLogin={() => {
+          setIsSignupModalOpen(false)
+          setIsLoginModalOpen(true)
+        }}
       />
 
       {/* Main Content */}

--- a/components/login-modal.tsx
+++ b/components/login-modal.tsx
@@ -15,9 +15,10 @@ import { motion } from "framer-motion"
 type LoginModalProps = {
   isOpen: boolean
   onClose: () => void
+  onOpenSignup?: () => void
 }
 
-export function LoginModal({ isOpen, onClose }: LoginModalProps) {
+export function LoginModal({ isOpen, onClose, onOpenSignup }: LoginModalProps) {
   const { login } = useAuth()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
@@ -167,8 +168,7 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
                     onClick={(e) => {
                       e.preventDefault()
                       onClose()
-                      // This would typically open the signup modal
-                      alert("This would open the signup modal")
+                      onOpenSignup && onOpenSignup()
                     }}
                 >
                   Create Account

--- a/components/shared/header.tsx
+++ b/components/shared/header.tsx
@@ -65,10 +65,25 @@ export function Header() {
       </div>
 
       {/* Login Modal */}
-      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
+      <LoginModal
+        isOpen={isLoginModalOpen}
+        onClose={() => setIsLoginModalOpen(false)}
+        onOpenSignup={() => {
+          setIsLoginModalOpen(false)
+          setIsSignupModalOpen(true)
+        }}
+      />
 
       {/* Signup Modal */}
-      <SignupModal isOpen={isSignupModalOpen} onClose={() => setIsSignupModalOpen(false)} onSignupSuccess={() => {}} />
+      <SignupModal
+        isOpen={isSignupModalOpen}
+        onClose={() => setIsSignupModalOpen(false)}
+        onSignupSuccess={() => {}}
+        onOpenLogin={() => {
+          setIsSignupModalOpen(false)
+          setIsLoginModalOpen(true)
+        }}
+      />
     </header>
   )
 }

--- a/components/ship-now/login-prompt.tsx
+++ b/components/ship-now/login-prompt.tsx
@@ -53,13 +53,24 @@ export function LoginPrompt() {
       </Card>
 
       {/* Login Modal */}
-      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
+      <LoginModal
+        isOpen={isLoginModalOpen}
+        onClose={() => setIsLoginModalOpen(false)}
+        onOpenSignup={() => {
+          setIsLoginModalOpen(false)
+          setIsSignupModalOpen(true)
+        }}
+      />
 
       {/* Signup Modal */}
       <SignupModal
         isOpen={isSignupModalOpen}
         onClose={() => setIsSignupModalOpen(false)}
         onSignupSuccess={handleSignupSuccess}
+        onOpenLogin={() => {
+          setIsSignupModalOpen(false)
+          setIsLoginModalOpen(true)
+        }}
       />
     </div>
   )

--- a/components/signup-modal.tsx
+++ b/components/signup-modal.tsx
@@ -17,9 +17,10 @@ type SignupModalProps = {
   isOpen: boolean
   onClose: () => void
   onSignupSuccess: (email: string, userId: string) => void
+  onOpenLogin?: () => void
 }
 
-export function SignupModal({ isOpen, onClose, onSignupSuccess }: SignupModalProps) {
+export function SignupModal({ isOpen, onClose, onSignupSuccess, onOpenLogin }: SignupModalProps) {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
@@ -292,8 +293,7 @@ export function SignupModal({ isOpen, onClose, onSignupSuccess }: SignupModalPro
                     onClick={(e) => {
                       e.preventDefault()
                       onClose()
-                      // This would typically open the login modal
-                      alert("This would open the login modal")
+                      onOpenLogin && onOpenLogin()
                     }}
                 >
                   Sign In Instead


### PR DESCRIPTION
## Summary
- add cross-modal open callbacks to login and signup modals
- wire up header, ship-now prompt and landing page to use new callbacks

## Testing
- `pnpm install`
- `pnpm lint` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68659ddb5a1083298bef034a907abd5a