### PR TITLE
Add email verification page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { AuthProvider } from "@/lib/auth-context"
 import { ThemeProvider } from "@/components/theme-provider"
+import { Toaster } from "@/components/ui/toaster"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -23,12 +24,9 @@ export default function RootLayout({
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           <AuthProvider>{children}</AuthProvider>
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>
   )
 }
-
-
-
-import './globals.css'

--- a/app/verifyemail/[token]/page.tsx
+++ b/app/verifyemail/[token]/page.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "@/hooks/use-toast"
+import { AUTH_MICROSERVICE_URL } from "@/lib/config"
+
+export default function VerifyEmailPage({ params }: { params: { token: string } }) {
+  const router = useRouter()
+
+  useEffect(() => {
+    const verify = async () => {
+      try {
+        const res = await fetch(
+          `${AUTH_MICROSERVICE_URL}/verify-email?token=${params.token}`,
+          {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: "",
+          }
+        )
+
+        if (res.ok) {
+          toast({
+            title: "Email verified",
+            description: "Your email has been confirmed. You can now log in.",
+          })
+        } else {
+          toast({
+            title: "Verification failed",
+            description: "We couldn't verify your email. Please try again.",
+          })
+        }
+      } catch (error) {
+        console.error("Email verification error:", error)
+        toast({
+          title: "Verification error",
+          description: "An unexpected error occurred while verifying your email.",
+        })
+      } finally {
+        setTimeout(() => router.push("/"), 3000)
+      }
+    }
+
+    verify()
+  }, [params.token, router])
+
+  return (
+    <div className="flex items-center justify-center py-20">
+      <p className="text-muted-foreground">Verifying your email...</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Toaster component to layout for global toast support
- create dynamic `/verifyemail/[token]` page
  - calls backend to verify email via configured auth base url
  - shows success/failure toast then redirects to landing page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a3bc6f908329a7eacc58e8c5a63d