### PR TITLE
Show verification page after signup

### DIFF
--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -4,11 +4,11 @@ import { AUTH_MICROSERVICE_URL, getEndpointUrl } from "@/lib/config"
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { email, uid } = body
+    const { email } = body
 
     // Validate required fields
-    if (!email || !uid) {
-      return NextResponse.json({ message: "Email and user ID are required" }, { status: 400 })
+    if (!email) {
+      return NextResponse.json({ message: "Email is required" }, { status: 400 })
     }
 
     // Use the endpoint from our centralized configuration
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
         Accept: "application/json",
         "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
       },
-      body: JSON.stringify({ email, uid }),
+      body: JSON.stringify({ email }),
     })
 
     // Get the response data

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -87,8 +87,20 @@ export default function LandingPage() {
     setVerificationUserId("")
   }
 
-  // Determine what to show based on user status
+  // Determine what to show based on user status or signup state
   const renderContent = () => {
+    if (showVerification) {
+      return (
+        <div className="container py-20">
+          <VerificationPending
+            email={verificationEmail || "your email"}
+            userId={verificationUserId}
+            onClose={handleCloseVerification}
+          />
+        </div>
+      )
+    }
+
     if (!user) {
       return <LandingContent />
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,20 @@ export default function LandingPage() {
   const [isSignupModalOpen, setIsSignupModalOpen] = useState(false)
   const [showVerification, setShowVerification] = useState(false)
   const [verificationEmail, setVerificationEmail] = useState("")
-  const [verificationUserId, setVerificationUserId] = useState("")
+  // Email is enough for resending verification now
+
+  // When the page loads, check if we stored a signup email
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem("maplexpress_signup_email")
+      if (saved) {
+        setVerificationEmail(saved)
+        setShowVerification(true)
+      }
+    } catch (e) {
+      console.error("Failed to read signup email", e)
+    }
+  }, [])
 
   // Check user status when user changes
   useEffect(() => {
@@ -53,7 +66,6 @@ export default function LandingPage() {
             }
           }
 
-          setVerificationUserId(user.userId)
           setShowVerification(true)
           break
 
@@ -74,17 +86,20 @@ export default function LandingPage() {
     }
   }, [user])
 
-  const handleSignupSuccess = (email: string, userId: string) => {
+  const handleSignupSuccess = (email: string) => {
     setIsSignupModalOpen(false)
     setVerificationEmail(email)
-    setVerificationUserId(userId)
     setShowVerification(true)
   }
 
   const handleCloseVerification = () => {
     setShowVerification(false)
     setVerificationEmail("")
-    setVerificationUserId("")
+    try {
+      localStorage.removeItem("maplexpress_signup_email")
+    } catch (e) {
+      console.error("Failed to remove signup email", e)
+    }
   }
 
   // Determine what to show based on user status or signup state
@@ -94,7 +109,6 @@ export default function LandingPage() {
         <div className="container py-20">
           <VerificationPending
             email={verificationEmail || "your email"}
-            userId={verificationUserId}
             onClose={handleCloseVerification}
           />
         </div>
@@ -111,7 +125,6 @@ export default function LandingPage() {
           <div className="container py-20">
             <VerificationPending
               email={verificationEmail || "your email"}
-              userId={user.userId}
               onClose={handleCloseVerification}
             />
           </div>

--- a/components/shared/header.tsx
+++ b/components/shared/header.tsx
@@ -78,7 +78,7 @@ export function Header() {
       <SignupModal
         isOpen={isSignupModalOpen}
         onClose={() => setIsSignupModalOpen(false)}
-        onSignupSuccess={() => {}}
+        onSignupSuccess={(email: string) => {}}
         onOpenLogin={() => {
           setIsSignupModalOpen(false)
           setIsLoginModalOpen(true)

--- a/components/ship-now/login-prompt.tsx
+++ b/components/ship-now/login-prompt.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { LoginModal } from "@/components/login-modal"
 import { SignupModal } from "@/components/signup-modal"
 import { Package } from "lucide-react"
+import { VerificationPending } from "@/components/verification-pending"
 
 export function LoginPrompt() {
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
@@ -13,10 +14,27 @@ export function LoginPrompt() {
   const [verificationEmail, setVerificationEmail] = useState("")
   const [verificationUserId, setVerificationUserId] = useState("")
 
+  const handleCloseVerification = () => {
+    setVerificationEmail("")
+    setVerificationUserId("")
+  }
+
   const handleSignupSuccess = (email: string, userId: string) => {
     setIsSignupModalOpen(false)
     setVerificationEmail(email)
     setVerificationUserId(userId)
+  }
+
+  if (verificationEmail) {
+    return (
+      <div className="container py-20 flex items-center justify-center">
+        <VerificationPending
+          email={verificationEmail}
+          userId={verificationUserId}
+          onClose={handleCloseVerification}
+        />
+      </div>
+    )
   }
 
   return (

--- a/components/ship-now/login-prompt.tsx
+++ b/components/ship-now/login-prompt.tsx
@@ -12,17 +12,19 @@ export function LoginPrompt() {
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
   const [isSignupModalOpen, setIsSignupModalOpen] = useState(false)
   const [verificationEmail, setVerificationEmail] = useState("")
-  const [verificationUserId, setVerificationUserId] = useState("")
 
   const handleCloseVerification = () => {
     setVerificationEmail("")
-    setVerificationUserId("")
+    try {
+      localStorage.removeItem("maplexpress_signup_email")
+    } catch (e) {
+      console.error("Failed to remove signup email", e)
+    }
   }
 
-  const handleSignupSuccess = (email: string, userId: string) => {
+  const handleSignupSuccess = (email: string) => {
     setIsSignupModalOpen(false)
     setVerificationEmail(email)
-    setVerificationUserId(userId)
   }
 
   if (verificationEmail) {
@@ -30,7 +32,6 @@ export function LoginPrompt() {
       <div className="container py-20 flex items-center justify-center">
         <VerificationPending
           email={verificationEmail}
-          userId={verificationUserId}
           onClose={handleCloseVerification}
         />
       </div>

--- a/components/signup-modal.tsx
+++ b/components/signup-modal.tsx
@@ -16,7 +16,7 @@ import { motion } from "framer-motion"
 type SignupModalProps = {
   isOpen: boolean
   onClose: () => void
-  onSignupSuccess: (email: string, userId: string) => void
+  onSignupSuccess: (email: string) => void
   onOpenLogin?: () => void
 }
 
@@ -96,8 +96,13 @@ export function SignupModal({ isOpen, onClose, onSignupSuccess, onOpenLogin }: S
       const data = await response.json()
 
       if (response.ok) {
-        // Call the success callback with email and userId
-        onSignupSuccess(email, data.userId)
+        // Store email for verification purposes and notify parent
+        try {
+          localStorage.setItem("maplexpress_signup_email", email)
+        } catch (e) {
+          console.error("Failed to store signup email", e)
+        }
+        onSignupSuccess(email)
 
         // Reset form
         setEmail("")

--- a/components/verification-pending.tsx
+++ b/components/verification-pending.tsx
@@ -9,11 +9,10 @@ import { useAuth } from "@/lib/auth-context"
 
 type VerificationPendingProps = {
   email: string
-  userId: string
   onClose?: () => void
 }
 
-export function VerificationPending({ email, userId, onClose }: VerificationPendingProps) {
+export function VerificationPending({ email, onClose }: VerificationPendingProps) {
   const { resendVerificationEmail } = useAuth()
   const [isResending, setIsResending] = useState(false)
   const [resendSuccess, setResendSuccess] = useState(false)
@@ -25,7 +24,7 @@ export function VerificationPending({ email, userId, onClose }: VerificationPend
     setResendSuccess(false)
 
     try {
-      const result = await resendVerificationEmail(email, userId)
+      const result = await resendVerificationEmail(email)
 
       if (result.success) {
         setResendSuccess(true)

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -93,7 +93,7 @@ type AuthContextType = {
   createOrganizationProfile: (
     profileData: Omit<OrganizationProfile, "id" | "status" | "createdAt" | "updatedAt">,
   ) => Promise<{ success: boolean; message: string; profile?: OrganizationProfile }>
-  resendVerificationEmail: (email: string, userId: string) => Promise<{ success: boolean; message: string }>
+  resendVerificationEmail: (email: string) => Promise<{ success: boolean; message: string }>
   fetchUserProfile: () => Promise<void>
 }
 
@@ -213,14 +213,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   // Add function to resend verification email
-  const resendVerificationEmail = async (email: string, userId: string) => {
+  const resendVerificationEmail = async (email: string) => {
     try {
       const response = await fetch("/api/auth/resend-verification", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ email, uid: userId }),
+        body: JSON.stringify({ email }),
       })
 
       const data = await response.json()


### PR DESCRIPTION
## Summary
- display verification pending page when signup completes
- show same instructions in ship-now login prompt

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm build` *(fails: could not fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6865b1bc96388329936f46c8efe702c1