### PR TITLE
Fix missing email in org profile creation

### DIFF
--- a/app/api/profile/organization/route.ts
+++ b/app/api/profile/organization/route.ts
@@ -12,6 +12,7 @@ export async function POST(request: NextRequest) {
       !pointOfContact ||
       !pointOfContact.name ||
       !pointOfContact.position ||
+      !pointOfContact.email ||
       !pointOfContact.phone
     ) {
       return NextResponse.json({ message: "Missing required fields" }, { status: 400 })

--- a/components/organization-profile-form.tsx
+++ b/components/organization-profile-form.tsx
@@ -16,6 +16,7 @@ export function OrganizationProfileForm() {
   const [name, setName] = useState("")
   const [contactName, setContactName] = useState("")
   const [position, setPosition] = useState("")
+  const [contactEmail, setContactEmail] = useState("")
   const [phone, setPhone] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -40,6 +41,7 @@ export function OrganizationProfileForm() {
         pointOfContact: {
           name: contactName,
           position,
+          email: contactEmail,
           phone,
         },
       })
@@ -97,6 +99,17 @@ export function OrganizationProfileForm() {
               value={position}
               onChange={(e) => setPosition(e.target.value)}
               placeholder="e.g., Director of Operations"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="contactEmail">Email</Label>
+            <Input
+              id="contactEmail"
+              type="email"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
               required
             />
           </div>

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -54,6 +54,7 @@ type OrganizationProfile = {
   pointOfContact: {
     name: string
     position: string
+    email: string
     phone: string
   }
   address?: Array<{


### PR DESCRIPTION
## Summary
- ensure contact email is collected when an organization completes their profile
- send `pointOfContact.email` to backend
- validate `pointOfContact.email` in profile API route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686882b1430c8329b7e1773d90d4babd