### PR TITLE
Fetch profile info by email after login

### DIFF
--- a/app/api/profile/individual/route.ts
+++ b/app/api/profile/individual/route.ts
@@ -54,12 +54,16 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    // Get the userId from query params
+    // Get the userId or email from query params
     const { searchParams } = new URL(request.url)
     const userId = searchParams.get("userId")
+    const email = searchParams.get("email")
 
-    if (!userId) {
-      return NextResponse.json({ message: "userId is required" }, { status: 400 })
+    if (!userId && !email) {
+      return NextResponse.json(
+        { message: "userId or email is required" },
+        { status: 400 },
+      )
     }
 
     // Get the authorization header
@@ -71,8 +75,12 @@ export async function GET(request: NextRequest) {
     const token = authHeader.split(" ")[1]
 
     // Use the correct base URL and endpoint
-    const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/individual?userId=${userId}`
+    const BASE_URL =
+      process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL ||
+      "http://localhost:30081/usermanagement"
+    const endpoint = userId
+      ? `${BASE_URL}/profile/individual?userId=${userId}`
+      : `${BASE_URL}/profile/individual?email=${email}`
 
     // Forward the request to your microservice
     const response = await fetch(endpoint, {

--- a/app/api/profile/organization/route.ts
+++ b/app/api/profile/organization/route.ts
@@ -59,12 +59,16 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    // Get the userId from query params
+    // Get the userId or email from query params
     const { searchParams } = new URL(request.url)
     const userId = searchParams.get("userId")
+    const email = searchParams.get("email")
 
-    if (!userId) {
-      return NextResponse.json({ message: "userId is required" }, { status: 400 })
+    if (!userId && !email) {
+      return NextResponse.json(
+        { message: "userId or email is required" },
+        { status: 400 },
+      )
     }
 
     // Get the authorization header
@@ -76,8 +80,12 @@ export async function GET(request: NextRequest) {
     const token = authHeader.split(" ")[1]
 
     // Use the correct base URL and endpoint
-    const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/organization?userId=${userId}`
+    const BASE_URL =
+      process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL ||
+      "http://localhost:30081/usermanagement"
+    const endpoint = userId
+      ? `${BASE_URL}/profile/organization?userId=${userId}`
+      : `${BASE_URL}/profile/organization?email=${email}`
 
     // Forward the request to your microservice
     const response = await fetch(endpoint, {

--- a/lib/profile-service.ts
+++ b/lib/profile-service.ts
@@ -44,6 +44,60 @@ export async function getOrganizationProfile(userId: string): Promise<Organizati
   return response.json()
 }
 
+// Get individual profile by email
+export async function getIndividualProfileByEmail(
+  email: string,
+): Promise<IndividualProfile> {
+  const accessToken = localStorage.getItem("maplexpress_access_token")
+
+  if (!accessToken) {
+    throw new Error("Not authenticated")
+  }
+
+  const response = await fetch(
+    `/api/profile/individual?email=${encodeURIComponent(email)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.message || "Failed to fetch individual profile")
+  }
+
+  return response.json()
+}
+
+// Get organization profile by email
+export async function getOrganizationProfileByEmail(
+  email: string,
+): Promise<OrganizationProfile> {
+  const accessToken = localStorage.getItem("maplexpress_access_token")
+
+  if (!accessToken) {
+    throw new Error("Not authenticated")
+  }
+
+  const response = await fetch(
+    `/api/profile/organization?email=${encodeURIComponent(email)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.message || "Failed to fetch organization profile")
+  }
+
+  return response.json()
+}
+
 // Update individual profile
 export async function updateIndividualProfile(
   userId: string,


### PR DESCRIPTION
## Summary
- fetch user profile after login regardless of status
- extend `fetchUserProfile` to query by email and store the profile
- allow API routes to query individual/organization profiles by `email`
- add helper functions to get profiles by email

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68693655c2b08329827d47b194d1f1fd