### PR TITLE
Add basic tracking page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
 import Link from "next/link"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
@@ -171,7 +172,7 @@ export default function LandingPage() {
             </Link>
           </nav>
           <div className="flex items-center gap-4">
-            <Link href="#track" className="text-sm font-medium hover:text-primary hidden md:block">
+            <Link href="/track" className="text-sm font-medium hover:text-primary hidden md:block">
               Track Package
             </Link>
             {isLoading ? (
@@ -273,7 +274,7 @@ export default function LandingPage() {
                   </Link>
                 </li>
                 <li>
-                  <Link href="#track" className="text-muted-foreground hover:text-primary">
+                  <Link href="/track" className="text-muted-foreground hover:text-primary">
                     Track Package
                   </Link>
                 </li>
@@ -356,6 +357,8 @@ export default function LandingPage() {
 
 // Extract the landing content to a separate component
 function LandingContent() {
+  const [trackingInput, setTrackingInput] = useState("")
+  const router = useRouter()
   return (
     <>
       {/* Hero Section */}
@@ -558,8 +561,21 @@ function LandingContent() {
               time.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 max-w-[600px] mx-auto">
-              <Input placeholder="Enter tracking number" className="flex-1" />
-              <Button>Track Now</Button>
+              <Input
+                value={trackingInput}
+                onChange={(e) => setTrackingInput(e.target.value)}
+                placeholder="Enter tracking number"
+                className="flex-1"
+              />
+              <Button
+                onClick={() => {
+                  if (trackingInput.trim()) {
+                    router.push(`/track?trackingNumber=${encodeURIComponent(trackingInput.trim())}`)
+                  }
+                }}
+              >
+                Track Now
+              </Button>
             </div>
           </div>
         </div>

--- a/app/track/page.tsx
+++ b/app/track/page.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useState, useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Header } from '@/components/shared/header'
+import { Footer } from '@/components/shared/footer'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { getTrackingEvents, type TrackingEvent } from '@/lib/tracking-service'
+import { format } from 'date-fns'
+
+export default function TrackingPage() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  const initial = searchParams.get('trackingNumber') || ''
+  const [trackingNumber, setTrackingNumber] = useState(initial)
+  const [events, setEvents] = useState<TrackingEvent[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (initial) {
+      handleTrack(initial)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleTrack = async (num?: string) => {
+    const tracking = (num ?? trackingNumber).trim()
+    if (!tracking) return
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await getTrackingEvents(tracking)
+      data.sort(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      )
+      setEvents(data)
+    } catch (e) {
+      console.error(e)
+      setError('Failed to fetch tracking information.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    router.replace(`/track?trackingNumber=${encodeURIComponent(trackingNumber)}`)
+    handleTrack()
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-1 py-12 bg-muted/20">
+        <div className="container max-w-xl mx-auto">
+          <h1 className="text-3xl font-bold mb-6 text-center">Track Your Package</h1>
+          <form onSubmit={onSubmit} className="flex flex-col sm:flex-row gap-4 mb-8">
+            <Input
+              value={trackingNumber}
+              onChange={(e) => setTrackingNumber(e.target.value)}
+              placeholder="Enter tracking number"
+              className="flex-1"
+            />
+            <Button type="submit" disabled={loading}>
+              Track Now
+            </Button>
+          </form>
+          {loading && <p className="text-center">Loading...</p>}
+          {error && <p className="text-center text-destructive mb-4">{error}</p>}
+          {events && events.length > 0 && (
+            <div className="relative pl-4 border-l border-border">
+              <TooltipProvider>
+                {events.map((ev, idx) => (
+                  <div key={idx} className="relative pb-8">
+                    <span className="absolute -left-2 top-1.5 h-3 w-3 rounded-full bg-primary" />
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="cursor-default">
+                          <p className="font-medium">{ev.status}</p>
+                          <p className="text-sm text-muted-foreground">
+                            {format(new Date(ev.timestamp), 'PPpp')}
+                          </p>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>{ev.statusMessage}</TooltipContent>
+                    </Tooltip>
+                  </div>
+                ))}
+              </TooltipProvider>
+            </div>
+          )}
+          {events && events.length === 0 && !loading && (
+            <p className="text-center">No tracking events found.</p>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -54,7 +54,7 @@ export function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="/#track" className="text-muted-foreground hover:text-primary">
+                <Link href="/track" className="text-muted-foreground hover:text-primary">
                   Track Package
                 </Link>
               </li>

--- a/components/shared/header.tsx
+++ b/components/shared/header.tsx
@@ -41,7 +41,7 @@ export function Header() {
           </Link>
         </nav>
         <div className="flex items-center gap-4">
-          <Link href="/#track" className="text-sm font-medium hover:text-primary hidden md:block">
+          <Link href="/track" className="text-sm font-medium hover:text-primary hidden md:block">
             Track Package
           </Link>
           {isLoading ? (

--- a/components/ship-now/shipping-success.tsx
+++ b/components/ship-now/shipping-success.tsx
@@ -41,7 +41,7 @@ export function ShippingSuccess({ orderNumber }: ShippingSuccessProps) {
             <Link href="/">Return to Home</Link>
           </Button>
           <Button variant="outline" asChild>
-            <Link href="#track">Track Your Package</Link>
+            <Link href="/track">Track Your Package</Link>
           </Button>
         </div>
       </motion.div>

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -14,6 +14,11 @@ export const PROFILE_SERVICE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL |
 // Order Service
 export const ORDER_SERVICE_URL = process.env.NEXT_PUBLIC_ORDER_SERVICE_URL || 'https://testapi.maplexpress.ca/ordermanagement';
 
+// Order Fulfilment Service
+export const ORDER_FULFILMENT_SERVICE_URL =
+  process.env.NEXT_PUBLIC_ORDER_FULFILMENT_SERVICE_URL ||
+  'https://testapi.maplexpress.ca/orderfulfilment';
+
 // Payment Service
 export const PRICING_PAYMENT_SERVICE_URL = process.env.NEXT_PUBLIC_PRICING_PAYMENT_SERVICE_URL || 'https://testapi.maplexpress.ca/paymentservice';
 

--- a/lib/tracking-service.ts
+++ b/lib/tracking-service.ts
@@ -1,0 +1,31 @@
+import { ORDER_FULFILMENT_SERVICE_URL, getEndpointUrl } from './config'
+
+export interface TrackingEvent {
+  status: string
+  timestamp: string
+  location?: {
+    latitude: number
+    longitude: number
+  } | null
+  statusMessage: string
+  driverComments: string | null
+  photographUrls: string[]
+}
+
+export async function getTrackingEvents(trackingNumber: string): Promise<TrackingEvent[]> {
+  const endpoint = getEndpointUrl(
+    ORDER_FULFILMENT_SERVICE_URL,
+    `v1/track/${trackingNumber}`
+  )
+
+  const res = await fetch(endpoint, {
+    headers: { Accept: 'application/json' },
+    method: 'GET'
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch tracking information')
+  }
+
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- create tracking service and page
- link Track Package buttons to `/track`
- wire up landing page Track Now button
- expose order fulfilment base URL

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6869400a88b883299c97a1e9871d1db3