### PR TITLE
Fix organization address APIs

### DIFF
--- a/app/addresses/page.tsx
+++ b/app/addresses/page.tsx
@@ -45,7 +45,7 @@ export default function AddressesPage() {
     setError(null)
 
     try {
-      const fetchedAddresses = await getAddresses(user.userId)
+      const fetchedAddresses = await getAddresses(user.userId, user.userType)
       setAddresses(fetchedAddresses)
     } catch (err) {
       console.error("Error fetching addresses:", err)
@@ -69,7 +69,7 @@ export default function AddressesPage() {
     if (!user) return
 
     try {
-      await deleteAddress(user.userId, addressId)
+      await deleteAddress(user.userId, addressId, user.userType)
       // Refresh the address list after deletion
       fetchAddresses()
     } catch (err) {
@@ -90,10 +90,10 @@ export default function AddressesPage() {
         await updateAddress(user.userId, {
           ...addressData,
           addressId: editingAddress.addressId,
-        })
+        }, user.userType)
       } else {
         // Create new address
-        await createAddress(user.userId, addressData)
+        await createAddress(user.userId, addressData, user.userType)
       }
 
       // Refresh the address list after adding/updating

--- a/app/api/profile/address/route.ts
+++ b/app/api/profile/address/route.ts
@@ -3,9 +3,10 @@ import { type NextRequest, NextResponse } from "next/server"
 // Get all addresses for a user
 export async function GET(request: NextRequest) {
   try {
-    // Get the userId from query params
+    // Get the userId and userType from query params
     const { searchParams } = new URL(request.url)
     const userId = searchParams.get("userId")
+    const userType = searchParams.get("userType") || "individualUser"
 
     if (!userId) {
       return NextResponse.json({ message: "userId is required" }, { status: 400 })
@@ -21,7 +22,9 @@ export async function GET(request: NextRequest) {
 
     // Use the correct base URL and endpoint
     const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/individual/${userId}/address`
+    const profileSegment =
+      userType === "businessUser" ? "organization" : "individual"
+    const endpoint = `${BASE_URL}/profile/${profileSegment}/${userId}/address`
 
     // Forward the request to your microservice
     const response = await fetch(endpoint, {
@@ -47,7 +50,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { userId, ...addressData } = body
+    const { userId, userType = "individualUser", ...addressData } = body
 
     if (!userId) {
       return NextResponse.json({ message: "userId is required" }, { status: 400 })
@@ -63,7 +66,9 @@ export async function POST(request: NextRequest) {
 
     // Use the correct base URL and endpoint
     const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/individual/${userId}/address`
+    const profileSegment =
+      userType === "businessUser" ? "organization" : "individual"
+    const endpoint = `${BASE_URL}/profile/${profileSegment}/${userId}/address`
 
     // Forward the request to your microservice
     const response = await fetch(endpoint, {
@@ -91,7 +96,7 @@ export async function POST(request: NextRequest) {
 export async function PATCH(request: NextRequest) {
   try {
     const body = await request.json()
-    const { userId, ...addressData } = body
+    const { userId, userType = "individualUser", ...addressData } = body
 
     if (!userId) {
       return NextResponse.json({ message: "userId is required" }, { status: 400 })
@@ -107,7 +112,9 @@ export async function PATCH(request: NextRequest) {
 
     // Use the correct base URL and endpoint
     const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/individual/${userId}/address`
+    const profileSegment =
+      userType === "businessUser" ? "organization" : "individual"
+    const endpoint = `${BASE_URL}/profile/${profileSegment}/${userId}/address`
 
     // Forward the request to your microservice
     const response = await fetch(endpoint, {
@@ -138,6 +145,7 @@ export async function DELETE(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const userId = searchParams.get("userId")
     const addressId = searchParams.get("addressId")
+    const userType = searchParams.get("userType") || "individualUser"
 
     if (!userId || !addressId) {
       return NextResponse.json({ message: "userId and addressId are required" }, { status: 400 })
@@ -153,7 +161,9 @@ export async function DELETE(request: NextRequest) {
 
     // Use the correct base URL and endpoint
     const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/individual/${userId}/address/${addressId}`
+    const profileSegment =
+      userType === "businessUser" ? "organization" : "individual"
+    const endpoint = `${BASE_URL}/profile/${profileSegment}/${userId}/address/${addressId}`
 
     // Forward the request to your microservice
     const response = await fetch(endpoint, {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -201,7 +201,9 @@ export default function Dashboard() {
       case "dashboard":
         return renderDashboardContent()
       case "addresses":
-        return <AddressManagement userId={user.userId} />
+        return (
+          <AddressManagement userId={user.userId} userType={user.userType} />
+        )
       case "settings":
         return <UserSettings userId={user.userId} userType={user.userType} />
       default:

--- a/components/dashboard/address-management.tsx
+++ b/components/dashboard/address-management.tsx
@@ -15,9 +15,10 @@ import { AlertCircle } from "lucide-react"
 
 interface AddressManagementProps {
   userId: string
+  userType: string
 }
 
-export function AddressManagement({ userId }: AddressManagementProps) {
+export function AddressManagement({ userId, userType }: AddressManagementProps) {
   const [addresses, setAddresses] = useState<Address[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -36,7 +37,7 @@ export function AddressManagement({ userId }: AddressManagementProps) {
     setError(null)
 
     try {
-      const fetchedAddresses = await getAddresses(userId)
+      const fetchedAddresses = await getAddresses(userId, userType)
       setAddresses(fetchedAddresses)
     } catch (err) {
       console.error("Error fetching addresses:", err)
@@ -58,7 +59,7 @@ export function AddressManagement({ userId }: AddressManagementProps) {
 
   const handleDeleteAddress = async (addressId: string) => {
     try {
-      await deleteAddress(userId, addressId)
+      await deleteAddress(userId, addressId, userType)
       // Refresh the address list after deletion
       fetchAddresses()
     } catch (err) {
@@ -77,10 +78,10 @@ export function AddressManagement({ userId }: AddressManagementProps) {
         await updateAddress(userId, {
           ...addressData,
           addressId: editingAddress.addressId,
-        })
+        }, userType)
       } else {
         // Create new address
-        await createAddress(userId, addressData)
+        await createAddress(userId, addressData, userType)
       }
 
       // Refresh the address list after adding/updating

--- a/components/ship-now/dropoff-address-form.tsx
+++ b/components/ship-now/dropoff-address-form.tsx
@@ -33,7 +33,7 @@ export function DropoffAddressForm({ selectedAddress, onSelectAddress, onNext, o
 
       try {
         setIsLoading(true)
-        const addresses = await getAddresses(user.userId)
+        const addresses = await getAddresses(user.userId, user.userType)
         setSavedAddresses(addresses)
       } catch (err) {
         console.error("Error fetching addresses:", err)

--- a/components/ship-now/payment-form.tsx
+++ b/components/ship-now/payment-form.tsx
@@ -198,7 +198,7 @@ export function PaymentForm({ orderData, onBack, onPaymentComplete, isProcessing
             if (!user) return;
             try {
                 setIsLoadingAddresses(true);
-                const addresses = await getAddresses(user.userId);
+                const addresses = await getAddresses(user.userId, user.userType);
                 setSavedAddresses(addresses);
             } catch (err) {
                 console.error("Error fetching addresses:", err);
@@ -306,9 +306,9 @@ export function PaymentForm({ orderData, onBack, onPaymentComplete, isProcessing
                 const { id, ...addressDataToSave } = addressWithId; 
                 await createAddress(user.userId, {
                     ...addressDataToSave,
-                     addressType: "billing", 
-                });
-                const addresses = await getAddresses(user.userId);
+                     addressType: "billing",
+                }, user.userType);
+                const addresses = await getAddresses(user.userId, user.userType);
                 setSavedAddresses(addresses);
             } catch (err) {
                 console.error("Error saving billing address:", err);

--- a/components/ship-now/pickup-address-form.tsx
+++ b/components/ship-now/pickup-address-form.tsx
@@ -33,7 +33,7 @@ export function PickupAddressForm({ selectedAddress, onSelectAddress, onNext, on
 
       try {
         setIsLoading(true)
-        const addresses = await getAddresses(user.userId)
+        const addresses = await getAddresses(user.userId, user.userType)
         setSavedAddresses(addresses)
       } catch (err) {
         console.error("Error fetching addresses:", err)

--- a/components/ship-now/ship-now-form.tsx
+++ b/components/ship-now/ship-now-form.tsx
@@ -173,7 +173,7 @@ export function ShipNowForm() {
           coordinates: address.coordinates,
         }
 
-        await createAddress(user.userId, addressData)
+        await createAddress(user.userId, addressData, user.userType)
       } catch (err) {
         console.error("Error saving address:", err)
         setError("Failed to save address for future use, but your order will continue.")
@@ -205,7 +205,7 @@ export function ShipNowForm() {
           coordinates: address.coordinates,
         }
 
-        await createAddress(user.userId, addressData)
+        await createAddress(user.userId, addressData, user.userType)
       } catch (err) {
         console.error("Error saving address:", err)
         setError("Failed to save address for future use, but your order will continue.")

--- a/lib/address-service.ts
+++ b/lib/address-service.ts
@@ -1,18 +1,24 @@
 import type { Address } from "@/types/address"
 
 // Get all addresses for a user
-export async function getAddresses(userId: string): Promise<Address[]> {
+export async function getAddresses(
+  userId: string,
+  userType: string,
+): Promise<Address[]> {
   const accessToken = localStorage.getItem("maplexpress_access_token")
 
   if (!accessToken) {
     throw new Error("Not authenticated")
   }
 
-  const response = await fetch(`/api/profile/address?userId=${userId}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
+  const response = await fetch(
+    `/api/profile/address?userId=${userId}&userType=${userType}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     },
-  })
+  )
 
   if (!response.ok) {
     const error = await response.json()
@@ -23,7 +29,11 @@ export async function getAddresses(userId: string): Promise<Address[]> {
 }
 
 // Create a new address
-export async function createAddress(userId: string, addressData: Omit<Address, "addressId">): Promise<Address> {
+export async function createAddress(
+  userId: string,
+  addressData: Omit<Address, "addressId">,
+  userType: string,
+): Promise<Address> {
   const accessToken = localStorage.getItem("maplexpress_access_token")
 
   if (!accessToken) {
@@ -31,15 +41,16 @@ export async function createAddress(userId: string, addressData: Omit<Address, "
   }
 
   const response = await fetch("/api/profile/address", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
-    },
-    body: JSON.stringify({
-      userId,
-      ...addressData,
-    }),
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        userId,
+        userType,
+        ...addressData,
+      }),
   })
 
   if (!response.ok) {
@@ -51,7 +62,11 @@ export async function createAddress(userId: string, addressData: Omit<Address, "
 }
 
 // Update an address
-export async function updateAddress(userId: string, addressData: Address): Promise<Address> {
+export async function updateAddress(
+  userId: string,
+  addressData: Address,
+  userType: string,
+): Promise<Address> {
   const accessToken = localStorage.getItem("maplexpress_access_token")
 
   if (!accessToken) {
@@ -59,15 +74,16 @@ export async function updateAddress(userId: string, addressData: Address): Promi
   }
 
   const response = await fetch("/api/profile/address", {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
-    },
-    body: JSON.stringify({
-      userId,
-      ...addressData,
-    }),
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        userId,
+        userType,
+        ...addressData,
+      }),
   })
 
   if (!response.ok) {
@@ -79,19 +95,26 @@ export async function updateAddress(userId: string, addressData: Address): Promi
 }
 
 // Delete an address
-export async function deleteAddress(userId: string, addressId: string): Promise<boolean> {
+export async function deleteAddress(
+  userId: string,
+  addressId: string,
+  userType: string,
+): Promise<boolean> {
   const accessToken = localStorage.getItem("maplexpress_access_token")
 
   if (!accessToken) {
     throw new Error("Not authenticated")
   }
 
-  const response = await fetch(`/api/profile/address?userId=${userId}&addressId=${addressId}`, {
-    method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
+  const response = await fetch(
+    `/api/profile/address?userId=${userId}&addressId=${addressId}&userType=${userType}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     },
-  })
+  )
 
   if (!response.ok) {
     const error = await response.json()


### PR DESCRIPTION
## Summary
- add user type awareness to profile address API routes
- update address service functions to accept user type
- propagate user type through address-related components
- pass user type when managing addresses in dashboard

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a752f04e08329b51d614337e6b959