### PR TITLE
Fix dashboard settings forms and password change

### DIFF
--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -4,9 +4,9 @@ import { AUTH_MICROSERVICE_URL, getEndpointUrl } from "@/lib/config"
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { userId, currentPassword, newPassword } = body
+    const { currentPassword, newPassword } = body
 
-    if (!userId || !currentPassword || !newPassword) {
+    if (!currentPassword || !newPassword) {
       return NextResponse.json({ message: "All fields are required" }, { status: 400 })
     }
 
@@ -19,7 +19,7 @@ export async function POST(request: NextRequest) {
     const token = authHeader.split(" ")[1]
 
     // Use the endpoint from our centralized configuration
-    const changePasswordEndpoint = getEndpointUrl(AUTH_MICROSERVICE_URL, 'change-password')
+    const changePasswordEndpoint = getEndpointUrl(AUTH_MICROSERVICE_URL, 'reset-password')
 
     // Forward the request to your microservice
     const response = await fetch(changePasswordEndpoint, {
@@ -30,7 +30,6 @@ export async function POST(request: NextRequest) {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        userId,
         currentPassword,
         newPassword,
       }),

--- a/app/api/profile/individual/updateinformation/route.ts
+++ b/app/api/profile/individual/updateinformation/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { PROFILE_SERVICE_URL } from "@/lib/config";
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config";
 
 export async function POST(request: NextRequest) {
   try {
@@ -16,7 +16,10 @@ export async function POST(request: NextRequest) {
     }
 
     const token = authHeader.split(" ")[1];
-    const endpoint = `${PROFILE_SERVICE_URL}/individual/updateinformation/${userId}`;
+    const endpoint = getEndpointUrl(
+      PROFILE_SERVICE_URL,
+      `/individual/updateinformation/${userId}`,
+    );
 
     const response = await fetch(endpoint, {
       method: "POST",

--- a/app/api/profile/individual/updateinformation/route.ts
+++ b/app/api/profile/individual/updateinformation/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { PROFILE_SERVICE_URL } from "@/lib/config";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { userId, phone } = body;
+
+    if (!userId || !phone) {
+      return NextResponse.json({ message: "userId and phone are required" }, { status: 400 });
+    }
+
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const endpoint = `${PROFILE_SERVICE_URL}/individual/updateinformation/${userId}`;
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "Accept-Language": "application/json",
+        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ phone }),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Update individual information error:", error);
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/profile/organization/updateinformation/route.ts
+++ b/app/api/profile/organization/updateinformation/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { PROFILE_SERVICE_URL } from "@/lib/config";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { userId, registrationNumber, taxID, industry, phone, website, pointOfContact } = body;
+
+    if (!userId) {
+      return NextResponse.json({ message: "userId is required" }, { status: 400 });
+    }
+
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const endpoint = `${PROFILE_SERVICE_URL}/organization/updateinformation/${userId}`;
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "Accept-Language": "application/json",
+        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ registrationNumber, taxID, industry, phone, website, pointOfContact }),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Update organization information error:", error);
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/profile/organization/updateinformation/route.ts
+++ b/app/api/profile/organization/updateinformation/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { PROFILE_SERVICE_URL } from "@/lib/config";
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config";
 
 export async function POST(request: NextRequest) {
   try {
@@ -16,7 +16,10 @@ export async function POST(request: NextRequest) {
     }
 
     const token = authHeader.split(" ")[1];
-    const endpoint = `${PROFILE_SERVICE_URL}/organization/updateinformation/${userId}`;
+    const endpoint = getEndpointUrl(
+      PROFILE_SERVICE_URL,
+      `/organization/updateinformation/${userId}`,
+    );
 
     const response = await fetch(endpoint, {
       method: "POST",

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -158,7 +158,7 @@ export default function SettingsPage() {
               </TabsContent>
 
               <TabsContent value="security" className="mt-0">
-                <ChangePassword userId={user.userId} />
+                <ChangePassword />
               </TabsContent>
             </Tabs>
           </div>

--- a/components/change-password.tsx
+++ b/components/change-password.tsx
@@ -4,18 +4,15 @@ import type React from "react"
 
 import { useState } from "react"
 import { changePassword } from "@/lib/profile-service"
+import { useToast } from "@/hooks/use-toast"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { AlertCircle, Loader2, Check, Eye, EyeOff } from "lucide-react"
+import { AlertCircle, Loader2, Eye, EyeOff } from "lucide-react"
 
-interface ChangePasswordProps {
-  userId: string
-}
-
-export function ChangePassword({ userId }: ChangePasswordProps) {
+export function ChangePassword() {
   const [formData, setFormData] = useState({
     currentPassword: "",
     newPassword: "",
@@ -25,9 +22,8 @@ export function ChangePassword({ userId }: ChangePasswordProps) {
   const [showNewPassword, setShowNewPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState(false)
   const [passwordError, setPasswordError] = useState<string | null>(null)
+  const { toast } = useToast()
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -60,8 +56,7 @@ export function ChangePassword({ userId }: ChangePasswordProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsSubmitting(true)
-    setError(null)
-    setSuccess(false)
+    setPasswordError(null)
 
     // Validate passwords match
     if (formData.newPassword !== formData.confirmPassword) {
@@ -77,15 +72,18 @@ export function ChangePassword({ userId }: ChangePasswordProps) {
     }
 
     try {
-      await changePassword(userId, formData.currentPassword, formData.newPassword)
-      setSuccess(true)
+      await changePassword(formData.currentPassword, formData.newPassword)
+      toast({ description: "Password updated successfully." })
       setFormData({
         currentPassword: "",
         newPassword: "",
         confirmPassword: "",
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : "An unexpected error occurred")
+      toast({
+        description: err instanceof Error ? err.message : "An unexpected error occurred",
+        variant: "destructive",
+      })
     } finally {
       setIsSubmitting(false)
     }
@@ -99,21 +97,6 @@ export function ChangePassword({ userId }: ChangePasswordProps) {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">
-          {error && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
-
-          {success && (
-            <Alert className="bg-green-50 border-green-200">
-              <Check className="h-4 w-4 text-green-600" />
-              <AlertDescription className="text-green-600">
-                Your password has been changed successfully!
-              </AlertDescription>
-            </Alert>
-          )}
 
           {passwordError && (
             <Alert variant="destructive">

--- a/components/dashboard/user-settings.tsx
+++ b/components/dashboard/user-settings.tsx
@@ -125,7 +125,7 @@ export function UserSettings({ userId, userType }: UserSettingsProps) {
             </TabsContent>
 
             <TabsContent value="security" className="mt-0">
-              <ChangePassword userId={userId} />
+              <ChangePassword />
             </TabsContent>
           </Tabs>
         </div>

--- a/components/individual-settings.tsx
+++ b/components/individual-settings.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 
 import { useState } from "react"
 import type { IndividualProfile } from "@/types/profile"
-import { updateIndividualProfile } from "@/lib/profile-service"
+import { updateIndividualInformation } from "@/lib/profile-service"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -20,17 +20,15 @@ interface IndividualSettingsProps {
 
 export function IndividualSettings({ profile, onProfileUpdate }: IndividualSettingsProps) {
   const [formData, setFormData] = useState({
-    firstName: profile.firstName,
-    lastName: profile.lastName,
-    phone: profile.phone,
+    phone: profile.phone || "",
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target
-    setFormData((prev) => ({ ...prev, [name]: value }))
+    const { value } = e.target
+    setFormData({ phone: value })
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -40,7 +38,7 @@ export function IndividualSettings({ profile, onProfileUpdate }: IndividualSetti
     setSuccess(false)
 
     try {
-      await updateIndividualProfile(profile.userId, formData)
+      await updateIndividualInformation(profile.userId, formData.phone)
       setSuccess(true)
       onProfileUpdate()
     } catch (err) {
@@ -78,12 +76,12 @@ export function IndividualSettings({ profile, onProfileUpdate }: IndividualSetti
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="firstName">First Name</Label>
-                <Input id="firstName" name="firstName" value={formData.firstName} onChange={handleChange} required />
+                <Input id="firstName" value={profile.firstName} disabled className="bg-muted" />
               </div>
 
               <div className="space-y-2">
                 <Label htmlFor="lastName">Last Name</Label>
-                <Input id="lastName" name="lastName" value={formData.lastName} onChange={handleChange} required />
+                <Input id="lastName" value={profile.lastName} disabled className="bg-muted" />
               </div>
             </div>
 

--- a/components/organization-settings.tsx
+++ b/components/organization-settings.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 
 import { useState } from "react"
 import type { OrganizationProfile } from "@/types/profile"
-import { updateOrganizationProfile } from "@/lib/profile-service"
+import { updateOrganizationInformation } from "@/lib/profile-service"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -19,18 +19,16 @@ interface OrganizationSettingsProps {
 
 export function OrganizationSettings({ profile, onProfileUpdate }: OrganizationSettingsProps) {
   const [formData, setFormData] = useState({
-    name: profile.name,
     registrationNumber: profile.registrationNumber || "",
     taxID: profile.taxID || "",
     industry: profile.industry || "",
     phone: profile.phone,
-    email: profile.email,
     website: profile.website || "",
     pointOfContact: {
-      name: profile.pointOfContact.name,
-      position: profile.pointOfContact.position,
-      email: profile.pointOfContact.email,
-      phone: profile.pointOfContact.phone,
+      name: profile.pointOfContact.name || "",
+      position: profile.pointOfContact.position || "",
+      email: profile.pointOfContact.email || "",
+      phone: profile.pointOfContact.phone || "",
     },
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -60,7 +58,7 @@ export function OrganizationSettings({ profile, onProfileUpdate }: OrganizationS
     setSuccess(false)
 
     try {
-      await updateOrganizationProfile(profile.userId, formData)
+      await updateOrganizationInformation(profile.userId, formData)
       setSuccess(true)
       onProfileUpdate()
     } catch (err) {
@@ -97,7 +95,7 @@ export function OrganizationSettings({ profile, onProfileUpdate }: OrganizationS
 
             <div className="space-y-2">
               <Label htmlFor="name">Organization Name</Label>
-              <Input id="name" name="name" value={formData.name} onChange={handleChange} required />
+              <Input id="name" value={profile.name} disabled className="bg-muted" />
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -125,7 +123,7 @@ export function OrganizationSettings({ profile, onProfileUpdate }: OrganizationS
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="email">Email</Label>
-                <Input id="email" name="email" type="email" value={formData.email} onChange={handleChange} required />
+                <Input id="email" value={profile.email} disabled className="bg-muted" />
               </div>
 
               <div className="space-y-2">

--- a/components/organization-settings.tsx
+++ b/components/organization-settings.tsx
@@ -25,10 +25,10 @@ export function OrganizationSettings({ profile, onProfileUpdate }: OrganizationS
     phone: profile.phone,
     website: profile.website || "",
     pointOfContact: {
-      name: profile.pointOfContact.name || "",
-      position: profile.pointOfContact.position || "",
-      email: profile.pointOfContact.email || "",
-      phone: profile.pointOfContact.phone || "",
+      name: profile.pointOfContact?.name || "",
+      position: profile.pointOfContact?.position || "",
+      email: profile.pointOfContact?.email || "",
+      phone: profile.pointOfContact?.phone || "",
     },
   })
   const [isSubmitting, setIsSubmitting] = useState(false)

--- a/lib/profile-service.ts
+++ b/lib/profile-service.ts
@@ -162,9 +162,76 @@ export async function updateOrganizationProfile(
   return response.json()
 }
 
+export async function updateIndividualInformation(
+  userId: string,
+  phone: string,
+): Promise<IndividualProfile> {
+  const accessToken = localStorage.getItem("maplexpress_access_token")
+
+  if (!accessToken) {
+    throw new Error("Not authenticated")
+  }
+
+  const response = await fetch(`/api/profile/individual/updateinformation`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ userId, phone }),
+  })
+
+  const data = await response.json()
+
+  if (!response.ok) {
+    throw new Error(data.message || "Failed to update information")
+  }
+
+  return data
+}
+
+export async function updateOrganizationInformation(
+  userId: string,
+  info: {
+    registrationNumber?: string
+    taxID?: string
+    industry?: string
+    phone?: string
+    website?: string
+    pointOfContact: {
+      name?: string
+      position?: string
+      email?: string
+      phone?: string
+    }
+  },
+): Promise<OrganizationProfile> {
+  const accessToken = localStorage.getItem("maplexpress_access_token")
+
+  if (!accessToken) {
+    throw new Error("Not authenticated")
+  }
+
+  const response = await fetch(`/api/profile/organization/updateinformation`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ userId, ...info }),
+  })
+
+  const data = await response.json()
+
+  if (!response.ok) {
+    throw new Error(data.message || "Failed to update information")
+  }
+
+  return data
+}
+
 // Change password
 export async function changePassword(
-  userId: string,
   currentPassword: string,
   newPassword: string,
 ): Promise<{ success: boolean; message: string }> {
@@ -181,7 +248,6 @@ export async function changePassword(
       Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
-      userId,
       currentPassword,
       newPassword,
     }),


### PR DESCRIPTION
## Summary
- add backend API routes for updating individual or organization information
- wire profile service helpers to new endpoints
- restrict editable fields in settings forms
- update password change flow to call reset-password endpoint and show toasts
- adjust dashboard and settings pages to use updated components

## Testing
- `pnpm lint` *(fails: Next.js requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686aae43bf6483299086584f58418b72