### PR TITLE
Centralize server auth, add authenticated proxy, and migrate client API to `apiFetch`

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { decodeJwtPayload, cognitoRequest, getCognitoClientId } from "@/lib/cognito"
+import { applyAuthCookies } from "@/lib/server-auth"
 
 type CognitoInitiateAuthResponse = {
   AuthenticationResult?: {
@@ -80,26 +81,7 @@ export async function POST(request: NextRequest) {
       { status: 200 },
     )
 
-    const isSecure = process.env.NODE_ENV === "production"
-    const accessTokenCookieOptions = {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: "lax" as const,
-      path: "/",
-      maxAge: 60 * 60,
-    }
-    const refreshTokenCookieOptions = {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: "lax" as const,
-      path: "/",
-      maxAge: 60 * 60 * 24 * 5,
-    }
-
-    response.cookies.set("maplexpress_access_token", accessToken, accessTokenCookieOptions)
-    response.cookies.set("accessToken", accessToken, accessTokenCookieOptions)
-    response.cookies.set("maplexpress_id_token", idToken, accessTokenCookieOptions)
-    response.cookies.set("maplexpress_refresh_token", refreshToken, refreshTokenCookieOptions)
+    applyAuthCookies(response, { accessToken, refreshToken, idToken })
 
     return response
   } catch (error) {

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,20 +1,8 @@
 import { NextResponse } from "next/server"
+import { clearAuthCookies } from "@/lib/server-auth"
 
 export async function POST() {
   const response = NextResponse.json({ success: true }, { status: 200 })
-  const isSecure = process.env.NODE_ENV === "production"
-  const cookieOptions = {
-    httpOnly: true,
-    secure: isSecure,
-    sameSite: "lax" as const,
-    path: "/",
-    maxAge: 0,
-  }
-
-  response.cookies.set("maplexpress_access_token", "", cookieOptions)
-  response.cookies.set("accessToken", "", cookieOptions)
-  response.cookies.set("maplexpress_refresh_token", "", cookieOptions)
-  response.cookies.set("maplexpress_id_token", "", cookieOptions)
-
+  clearAuthCookies(response)
   return response
 }

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,37 +1,31 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { AUTH_REFRESH_URL } from "@/lib/config"
+import { maybeRefreshTokens, getAuthTokensFromRequest, applyAuthCookies, clearAuthCookies } from "@/lib/server-auth"
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json()
-    const { refreshToken } = body
+    const tokens = getAuthTokensFromRequest(request)
 
-    if (!refreshToken) {
-      return NextResponse.json({ message: "Refresh token is required" }, { status: 400 })
+    if (!tokens.refreshToken) {
+      const response = NextResponse.json({ message: "Refresh token is required" }, { status: 400 })
+      clearAuthCookies(response)
+      return response
     }
 
-    // Use the refresh URL from our centralized configuration
+    const refreshedTokens = await maybeRefreshTokens(tokens, request)
 
-    const response = await fetch(AUTH_REFRESH_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "Accept-Language": "application/json",
-        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
-      },
-      body: JSON.stringify({ refreshToken }),
-    })
-
-    const data = await response.json()
-
-    if (response.ok) {
-      return NextResponse.json(data, { status: 200 })
-    } else {
-      return NextResponse.json({ message: data.message || "Failed to refresh token" }, { status: response.status })
+    if (!refreshedTokens) {
+      const response = NextResponse.json({ message: "Failed to refresh token" }, { status: 401 })
+      clearAuthCookies(response)
+      return response
     }
+
+    const response = NextResponse.json({ success: true }, { status: 200 })
+    applyAuthCookies(response, refreshedTokens)
+    return response
   } catch (error) {
     console.error("Token refresh error:", error)
-    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
+    const response = NextResponse.json({ message: "Internal server error" }, { status: 500 })
+    clearAuthCookies(response)
+    return response
   }
 }

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,40 +1,15 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return (
-      request.cookies.get("accessToken")?.value ||
-      request.cookies.get("maplexpress_access_token")?.value ||
-      null
-    )
-  }
-
-  return authHeader.split(" ")[1]
-}
-
-function buildHeaders(token: string | null, contentType = false): HeadersInit {
-  return {
-    accept: "application/json",
-    ...(contentType ? { "Content-Type": "application/json" } : {}),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  }
-}
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function GET(request: NextRequest) {
   try {
-    const token = getToken(request)
     const search = request.nextUrl.search
-    const url = getEndpointUrl(ORDER_SERVICE_URL, `orders${search}`)
-
-    const response = await fetch(url, {
+    return await proxyWithAuthRetry(request, {
       method: "GET",
-      headers: buildHeaders(token, true),
+      url: getEndpointUrl(ORDER_SERVICE_URL, `orders${search}`),
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Get orders error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
@@ -43,18 +18,13 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const token = getToken(request)
     const body = await request.json()
-    const url = getEndpointUrl(ORDER_SERVICE_URL, "orders")
-
-    const response = await fetch(url, {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: buildHeaders(token, true),
+      url: getEndpointUrl(ORDER_SERVICE_URL, "orders"),
       body: JSON.stringify(body),
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Create order error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
@@ -63,18 +33,13 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const token = getToken(request)
     const body = await request.json()
-    const url = getEndpointUrl(ORDER_SERVICE_URL, "orders")
-
-    const response = await fetch(url, {
+    return await proxyWithAuthRetry(request, {
       method: "PUT",
-      headers: buildHeaders(token, true),
+      url: getEndpointUrl(ORDER_SERVICE_URL, "orders"),
       body: JSON.stringify(body),
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Update order error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -1,49 +1,16 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { PRICING_PAYMENT_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return (
-      request.cookies.get("accessToken")?.value ||
-      request.cookies.get("maplexpress_access_token")?.value ||
-      null
-    )
-  }
-
-  return authHeader.split(" ")[1]
-}
-
-function buildHeaders(token: string | null): HeadersInit {
-  return {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  }
-}
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const token = getToken(request)
     const body = await request.json()
-
-    const response = await fetch(getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "payments/checkout"), {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: buildHeaders(token),
+      url: getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "payments/checkout"),
       body: JSON.stringify(body),
-      cache: "no-store",
+      contentTypeJson: true,
     })
-
-    const raw = await response.text()
-    if (!raw) {
-      return NextResponse.json({ message: response.ok ? "Checkout request completed" : "Checkout request failed" }, { status: response.status })
-    }
-
-    try {
-      return NextResponse.json(JSON.parse(raw), { status: response.status })
-    } catch {
-      return NextResponse.json({ message: raw }, { status: response.status })
-    }
   } catch (error) {
     console.error("Checkout payment error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/payments/moneris/finalize/route.ts
+++ b/app/api/payments/moneris/finalize/route.ts
@@ -1,56 +1,17 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { MONERIS_API_CONFIG } from "@/lib/config"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return (
-      request.cookies.get("accessToken")?.value ||
-      request.cookies.get("maplexpress_access_token")?.value ||
-      null
-    )
-  }
-
-  return authHeader.split(" ")[1]
-}
-
-function buildHeaders(token: string | null): HeadersInit {
-  return {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  }
-}
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const token = getToken(request)
     const body = await request.json()
 
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const response = await fetch(`${MONERIS_API_CONFIG.baseUrl}finalize`, {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: buildHeaders(token),
+      url: `${MONERIS_API_CONFIG.baseUrl}finalize`,
       body: JSON.stringify(body),
-      cache: "no-store",
+      contentTypeJson: true,
     })
-
-    const raw = await response.text()
-    if (!raw) {
-      return NextResponse.json(
-        { message: response.ok ? "Payment finalized successfully" : "Failed to finalize payment" },
-        { status: response.status },
-      )
-    }
-
-    try {
-      return NextResponse.json(JSON.parse(raw), { status: response.status })
-    } catch {
-      return NextResponse.json({ message: raw }, { status: response.status })
-    }
   } catch (error) {
     console.error("Finalize payment error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/profile/individual/updateinformation/route.ts
+++ b/app/api/profile/individual/updateinformation/route.ts
@@ -1,45 +1,24 @@
-import { type NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config";
+import { type NextRequest, NextResponse } from "next/server"
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { userId, phone } = body;
+    const body = await request.json()
+    const { userId, phone } = body
 
     if (!userId) {
-      return NextResponse.json({ message: "userId is required" }, { status: 400 });
+      return NextResponse.json({ message: "userId is required" }, { status: 400 })
     }
 
-    const cookieStore = cookies();
-    const token =
-      cookieStore.get("accessToken")?.value || cookieStore.get("maplexpress_access_token")?.value;
-
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
-    const endpoint = getEndpointUrl(
-      PROFILE_SERVICE_URL,
-      `/profile/individual/user/${userId}`,
-    );
-
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "Accept-Language": "application/json",
-        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual/user/${userId}`),
       body: JSON.stringify({ phone }),
-    });
-
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
+      contentTypeJson: true,
+    })
   } catch (error) {
-    console.error("Update individual information error:", error);
-    return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+    console.error("Update individual information error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }

--- a/app/api/profile/me/route.ts
+++ b/app/api/profile/me/route.ts
@@ -1,30 +1,14 @@
-import { NextResponse } from "next/server"
-import { cookies } from "next/headers"
+import { type NextRequest, NextResponse } from "next/server"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies()
-    const accessToken =
-      cookieStore.get("maplexpress_access_token")?.value ||
-      cookieStore.get("accessToken")?.value
-    const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-    if (!accessToken || !idToken) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/me"), {
+    return await proxyWithAuthRetry(request, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "X-Id-Token": idToken,
-      },
-      cache: "no-store",
+      url: getEndpointUrl(PROFILE_SERVICE_URL, "/me"),
+      includeIdToken: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Get /me error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/profile/onboarding/route.ts
+++ b/app/api/profile/onboarding/route.ts
@@ -1,35 +1,20 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { cookies } from "next/headers"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies()
-    const accessToken =
-      cookieStore.get("maplexpress_access_token")?.value ||
-      cookieStore.get("accessToken")?.value
-    const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-    if (!accessToken || !idToken) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
     const body = await request.json()
 
-    const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/onboarding"), {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-        "X-Id-Token": idToken,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, "/onboarding"),
       body: JSON.stringify(body),
+      includeIdToken: true,
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
-    console.error("Onboarding error:", error)
+    console.error("Onboarding route error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }

--- a/app/api/profile/organization/updateinformation/route.ts
+++ b/app/api/profile/organization/updateinformation/route.ts
@@ -1,63 +1,34 @@
-import { type NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config";
+import { type NextRequest, NextResponse } from "next/server"
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const {
-      userId,
-      registrationNumber,
-      taxID,
-      industry,
-      phone,
-      website,
-      pointOfContact,
-    } = body;
+    const body = await request.json()
+    const { userId, registrationNumber, taxId, industry, phone, websiteUrl, pointOfContact } = body
 
     if (!userId) {
-      return NextResponse.json({ message: "userId is required" }, { status: 400 });
+      return NextResponse.json({ message: "userId is required" }, { status: 400 })
     }
 
-    const cookieStore = cookies();
-    const token =
-      cookieStore.get("accessToken")?.value || cookieStore.get("maplexpress_access_token")?.value;
-
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
-    const endpoint = getEndpointUrl(
-      PROFILE_SERVICE_URL,
-      `/profile/organization/user/${userId}`,
-    );
-
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "Accept-Language": "application/json",
-        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization/user/${userId}`),
       body: JSON.stringify({
         registrationNumber,
-        taxId: taxID,
+        taxId,
         industry,
         phone,
-        websiteUrl: website,
+        websiteUrl,
         pointOfContactName: pointOfContact?.name,
         pointOfContactPosition: pointOfContact?.position,
         pointOfContactEmail: pointOfContact?.email,
         pointOfContactPhone: pointOfContact?.phone,
       }),
-    });
-
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
+      contentTypeJson: true,
+    })
   } catch (error) {
-    console.error("Update organization information error:", error);
-    return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+    console.error("Update organization information error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }

--- a/app/api/serviceability/route.ts
+++ b/app/api/serviceability/route.ts
@@ -1,37 +1,23 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { checkAuthenticatedServiceability } from "@/lib/serviceability-server"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return request.cookies.get("accessToken")?.value || request.cookies.get("maplexpress_access_token")?.value || null
-  }
-
-  return authHeader.split(" ")[1]
-}
+import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
-  const token = getToken(request)
-  if (!token) {
-    return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-  }
-
-  const body = (await request.json().catch(() => ({}))) as { latitude?: number; longitude?: number }
-  const latitude = Number(body.latitude)
-  const longitude = Number(body.longitude)
-
-  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
-    return NextResponse.json({ message: "Valid latitude and longitude are required." }, { status: 400 })
-  }
-
   try {
-    const response = await checkAuthenticatedServiceability(latitude, longitude, token)
-    return NextResponse.json(response)
+    const { latitude, longitude } = await request.json()
+
+    if (typeof latitude !== "number" || typeof longitude !== "number") {
+      return NextResponse.json({ message: "Latitude and longitude are required" }, { status: 400 })
+    }
+
+    return await proxyWithAuthRetry(request, {
+      method: "POST",
+      url: getEndpointUrl(ORDER_SERVICE_URL, "/service-zones/check-serviceability"),
+      body: JSON.stringify({ latitude, longitude }),
+      contentTypeJson: true,
+    })
   } catch (error) {
-    return NextResponse.json(
-      { message: error instanceof Error ? error.message : "Unable to check serviceability right now." },
-      { status: 502 },
-    )
+    console.error("Serviceability route error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }
-

--- a/lib/address-service.ts
+++ b/lib/address-service.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from "@/lib/client-api"
 import type { Address } from "@/types/address"
 
 type AddressInput = Omit<Address, "addressId" | "isPrimary"> & { isPrimary?: boolean }
@@ -18,7 +19,7 @@ async function getErrorMessage(response: Response, fallback: string) {
 
 // Get all addresses for a user
 export async function getAddresses(): Promise<Address[]> {
-  const response = await fetch("/api/profile/address")
+  const response = await apiFetch("/api/profile/address")
 
   if (!response.ok) {
     const message = await getErrorMessage(response, "Failed to fetch addresses")
@@ -32,7 +33,7 @@ export async function getAddresses(): Promise<Address[]> {
 export async function createAddress(
   addressData: AddressInput,
 ): Promise<Address> {
-  const response = await fetch("/api/profile/address", {
+  const response = await apiFetch("/api/profile/address", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -53,7 +54,7 @@ export async function updateAddress(
   addressId: string,
   addressData: AddressInput,
 ): Promise<Address> {
-  const response = await fetch(`/api/profile/address/${addressId}`, {
+  const response = await apiFetch(`/api/profile/address/${addressId}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
@@ -73,7 +74,7 @@ export async function updateAddress(
 export async function deleteAddress(
   addressId: string,
 ): Promise<boolean> {
-  const response = await fetch(`/api/profile/address/${addressId}`, {
+  const response = await apiFetch(`/api/profile/address/${addressId}`, {
     method: "DELETE",
   })
 

--- a/lib/admin-customer-billing-service.ts
+++ b/lib/admin-customer-billing-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 import type {
   AdminCustomerProfileListFilters,
   AdminEnablePayLaterRequest,
@@ -17,18 +17,6 @@ type ServiceResult<T> = {
   data: T | null
   error: ApiErrorResponse | null
   textError?: string | null
-}
-
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-  if (!accessToken || !idToken) return null
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "X-Id-Token": idToken,
-  }
 }
 
 function withJsonHeaders(headers: Record<string, string>) {
@@ -81,7 +69,7 @@ function normalizePageResponse<T>(payload: unknown, fallbackPage: number, fallba
 export async function listIndividualProfiles(
   filters: Omit<AdminCustomerProfileListFilters, "ownerType">,
 ): Promise<ServiceResult<PageResponse<IndividualProfile>>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const params = new URLSearchParams({ page: String(filters.page), size: String(filters.size) })
@@ -102,7 +90,7 @@ export async function listIndividualProfiles(
 }
 
 export async function getIndividualProfileById(id: string): Promise<ServiceResult<IndividualProfile>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual/${id}`), {
@@ -122,7 +110,7 @@ export async function getIndividualProfileById(id: string): Promise<ServiceResul
 export async function listOrganizationProfiles(
   filters: Omit<AdminCustomerProfileListFilters, "ownerType">,
 ): Promise<ServiceResult<PageResponse<OrganizationProfile>>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const params = new URLSearchParams({ page: String(filters.page), size: String(filters.size) })
@@ -149,7 +137,7 @@ export async function listOrganizationProfiles(
 }
 
 export async function getOrganizationProfileById(id: string): Promise<ServiceResult<OrganizationProfile>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization/${id}`), {
@@ -169,7 +157,7 @@ export async function getOrganizationProfileById(id: string): Promise<ServiceRes
 export async function enablePayLater(
   payload: AdminEnablePayLaterRequest,
 ): Promise<ServiceResult<ProfileBillingConfigurationResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/admin/profile/billing/pay-later/enable"), {
@@ -191,7 +179,7 @@ export async function enablePayLater(
 export async function updatePostpayStatus(
   payload: AdminUpdatePostpayStatusRequest,
 ): Promise<ServiceResult<ProfileBillingConfigurationResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/admin/profile/billing/postpay/status"), {

--- a/lib/admin-drivers-service.ts
+++ b/lib/admin-drivers-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 import type {
   AdminDriversQuery,
   AdminDriversResponse,
@@ -19,18 +19,6 @@ type ServiceResult<T> = {
   data: T | null
   error: ApiErrorResponse | null
   textError?: string | null
-}
-
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-  if (!accessToken || !idToken) return null
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "X-Id-Token": idToken,
-  }
 }
 
 async function parseError(response: Response): Promise<{ error: ApiErrorResponse | null; textError: string | null }> {
@@ -52,7 +40,7 @@ async function parseError(response: Response): Promise<{ error: ApiErrorResponse
 }
 
 export async function getAdminDrivers(query: AdminDriversQuery): Promise<ServiceResult<AdminDriversResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -79,7 +67,7 @@ export async function getAdminDrivers(query: AdminDriversQuery): Promise<Service
 }
 
 export async function getAdminDriverDetails(driverId: string): Promise<ServiceResult<DriverDetailsDto>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -103,7 +91,7 @@ export async function postAdminDriverAction(
   action: "approve" | "reject" | "suspend" | "unsuspend" | "terminate",
   payload: DriverActionRequestDto,
 ): Promise<ServiceResult<DriverActionResponseDto>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -130,7 +118,7 @@ export async function approveDriverLicense(
   driverId: string,
   payload: DriverLicenseApprovalRequestDto,
 ): Promise<ServiceResult<Record<string, unknown>>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -158,7 +146,7 @@ export async function approveDriverWorkEligibilityDocument(
   driverId: string,
   payload: DriverWorkEligibilityApprovalRequestDto,
 ): Promise<ServiceResult<Record<string, unknown>>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -186,7 +174,7 @@ export async function approveDriverWorkEligibilityDocument(
 }
 
 export async function inviteAdminDriver(payload: AdminInviteDriverRequest): Promise<ServiceResult<AdminInviteDriverResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }

--- a/lib/admin-pricing-service.ts
+++ b/lib/admin-pricing-service.ts
@@ -1,28 +1,13 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { PRICING_PAYMENT_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 import type { CreatePricingModelRequest, PricingApiError, PricingModel } from "@/types/pricing"
 
 type ServiceResult<T> = {
   data: T | null
   error: PricingApiError | null
   textError?: string | null
-}
-
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-  if (!accessToken || !idToken) return null
-
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "X-Id-Token": idToken,
-    Accept: "application/json",
-    "Content-Type": "application/json",
-  }
 }
 
 async function parseError(response: Response): Promise<{ error: PricingApiError | null; textError: string | null }> {
@@ -44,7 +29,7 @@ async function parseError(response: Response): Promise<{ error: PricingApiError 
 }
 
 export async function getAdminPricingModels(): Promise<ServiceResult<PricingModel[]>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true, includeJsonContentType: true })
 
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
@@ -52,7 +37,7 @@ export async function getAdminPricingModels(): Promise<ServiceResult<PricingMode
 
   const response = await fetch(getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "/pricing"), {
     method: "GET",
-    headers,
+    headers: { ...headers, Accept: "application/json" },
     cache: "no-store",
   })
 
@@ -65,7 +50,7 @@ export async function getAdminPricingModels(): Promise<ServiceResult<PricingMode
 }
 
 export async function createAdminPricingModel(payload: CreatePricingModelRequest): Promise<ServiceResult<PricingModel>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true, includeJsonContentType: true })
 
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
@@ -75,6 +60,7 @@ export async function createAdminPricingModel(payload: CreatePricingModelRequest
     method: "POST",
     headers: {
       ...headers,
+      Accept: "application/json",
     },
     body: JSON.stringify(payload),
     cache: "no-store",

--- a/lib/admin-service-zones-service.ts
+++ b/lib/admin-service-zones-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 import type {
   CreateServiceZoneRequest,
   CreateServiceZoneResponse,
@@ -21,18 +21,6 @@ type ZoneFilters = {
   active?: boolean
   city?: string
   station?: string
-}
-
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-  if (!accessToken || !idToken) return null
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "X-Id-Token": idToken,
-  }
 }
 
 function withJsonHeaders(headers: Record<string, string>) {
@@ -61,7 +49,7 @@ async function parseError(response: Response): Promise<{ error: ServiceZoneApiEr
 }
 
 export async function listServiceZones(filters: ZoneFilters = {}): Promise<ServiceResult<ListServiceZonesResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const params = new URLSearchParams()
@@ -85,7 +73,7 @@ export async function listServiceZones(filters: ZoneFilters = {}): Promise<Servi
 }
 
 export async function createServiceZone(payload: CreateServiceZoneRequest): Promise<ServiceResult<CreateServiceZoneResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(ORDER_SERVICE_URL, "/service-zones"), {
@@ -107,7 +95,7 @@ export async function toggleServiceZoneActive(
   id: string,
   payload: ToggleServiceZoneActiveRequest,
 ): Promise<ServiceResult<ToggleServiceZoneActiveResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(ORDER_SERVICE_URL, `/service-zones/${id}/active`), {

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, useEffect, type ReactNode } from "react"
 import { getMe, MeRequestError, type MeResponse } from "@/lib/me-service"
 import { submitOnboarding, type OnboardingPayload } from "@/lib/onboarding-service"
+import { apiFetch, cleanupLegacyTokenStorage, initSessionRefresh } from "@/lib/client-api"
 
 // Update the User type to match your API response
 type User = {
@@ -132,6 +133,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   const clearSession = () => {
+    cleanupLegacyTokenStorage()
     localStorage.removeItem("maplexpress_user_data")
     localStorage.removeItem("maplexpress_me")
     localStorage.removeItem("maplexpress_individual_profile")
@@ -173,6 +175,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const checkAuth = async () => {
       try {
+        cleanupLegacyTokenStorage()
+        await initSessionRefresh()
         const userData = localStorage.getItem("maplexpress_user_data")
         const cachedMe = localStorage.getItem("maplexpress_me")
 
@@ -291,7 +295,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Update the logout function:
   const logout = async () => {
     try {
-      await fetch("/api/auth/logout", { method: "POST" })
+      await apiFetch("/api/auth/logout", { method: "POST" })
     } catch (error) {
       console.error("Logout error:", error)
     } finally {
@@ -352,7 +356,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     profileData: Omit<IndividualProfile, "id" | "status" | "email" | "createdAt" | "updatedAt">,
   ) => {
     try {
-      const response = await fetch("/api/profile/individual", {
+      const response = await apiFetch("/api/profile/individual", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -390,7 +394,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     profileData: Omit<OrganizationProfile, "id" | "status" | "createdAt" | "updatedAt">,
   ) => {
     try {
-      const response = await fetch("/api/profile/organization", {
+      const response = await apiFetch("/api/profile/organization", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -467,7 +471,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     try {
       if (currentUser.userType === "individualUser") {
-        const response = await fetch(
+        const response = await apiFetch(
           `/api/profile/individual?email=${encodeURIComponent(currentUser.email)}`,
           {},
         )
@@ -482,7 +486,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           )
         }
       } else if (currentUser.userType === "businessUser") {
-        const response = await fetch(
+        const response = await apiFetch(
           `/api/profile/organization?email=${encodeURIComponent(currentUser.email)}`,
           {},
         )

--- a/lib/authenticated-proxy.ts
+++ b/lib/authenticated-proxy.ts
@@ -1,0 +1,59 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { applyAuthCookies, clearAuthCookies, getAuthTokensFromRequest, maybeRefreshTokens } from "@/lib/server-auth"
+
+type ProxyOptions = {
+  url: string
+  method: string
+  body?: string
+  includeIdToken?: boolean
+  contentTypeJson?: boolean
+}
+
+function headersFor(accessToken: string | null, idToken?: string | null, contentTypeJson?: boolean): HeadersInit {
+  return {
+    accept: "application/json",
+    ...(contentTypeJson ? { "Content-Type": "application/json" } : {}),
+    ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    ...(idToken ? { "X-Id-Token": idToken } : {}),
+  }
+}
+
+export async function proxyWithAuthRetry(request: NextRequest, options: ProxyOptions) {
+  const tokens = getAuthTokensFromRequest(request)
+
+  const first = await fetch(options.url, {
+    method: options.method,
+    headers: headersFor(tokens.accessToken, options.includeIdToken ? tokens.idToken : null, options.contentTypeJson),
+    ...(options.body ? { body: options.body } : {}),
+    cache: "no-store",
+  })
+
+  if (first.status !== 401) {
+    const data = await first.json().catch(() => ({}))
+    return NextResponse.json(data, { status: first.status })
+  }
+
+  const refreshed = await maybeRefreshTokens(tokens, request)
+  if (!refreshed?.accessToken) {
+    const response = NextResponse.json({ message: "Unauthorized" }, { status: 401 })
+    clearAuthCookies(response)
+    return response
+  }
+
+  const second = await fetch(options.url, {
+    method: options.method,
+    headers: headersFor(refreshed.accessToken, options.includeIdToken ? refreshed.idToken || tokens.idToken : null, options.contentTypeJson),
+    ...(options.body ? { body: options.body } : {}),
+    cache: "no-store",
+  })
+
+  const payload = await second.json().catch(() => ({}))
+  const response = NextResponse.json(payload, { status: second.status })
+  applyAuthCookies(response, refreshed)
+
+  if (second.status === 401) {
+    clearAuthCookies(response)
+  }
+
+  return response
+}

--- a/lib/aws-integration-service.ts
+++ b/lib/aws-integration-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { AWS_INTEGRATION_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 
 type PresignViewItem = {
   key: string
@@ -14,23 +14,11 @@ type PresignViewResponse = {
   items?: PresignViewItem[]
 }
 
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-
-  if (!accessToken) return null
-
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "Content-Type": "application/json",
-  }
-}
-
 export async function presignView(keys: string[]): Promise<Record<string, PresignViewItem>> {
   const uniqueKeys = Array.from(new Set(keys.filter(Boolean)))
   if (!uniqueKeys.length) return {}
 
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeJsonContentType: true })
   if (!headers) return {}
 
   const response = await fetch(getEndpointUrl(AWS_INTEGRATION_SERVICE_URL, "/v2/s3/presign/view"), {

--- a/lib/client-api.ts
+++ b/lib/client-api.ts
@@ -1,0 +1,68 @@
+"use client"
+
+let refreshPromise: Promise<boolean> | null = null
+
+const clearLegacyAuthStorage = () => {
+  localStorage.removeItem("maplexpress_access_token")
+  localStorage.removeItem("maplexpress_refresh_token")
+  sessionStorage.removeItem("maplexpress_access_token")
+  sessionStorage.removeItem("maplexpress_refresh_token")
+}
+
+const refreshSession = async (): Promise<boolean> => {
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      try {
+        const response = await fetch("/api/auth/refresh", {
+          method: "POST",
+          credentials: "include",
+          cache: "no-store",
+        })
+
+        if (!response.ok) {
+          clearLegacyAuthStorage()
+          return false
+        }
+
+        clearLegacyAuthStorage()
+        return true
+      } catch {
+        clearLegacyAuthStorage()
+        return false
+      } finally {
+        refreshPromise = null
+      }
+    })()
+  }
+
+  return refreshPromise
+}
+
+export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}, retry = true): Promise<Response> {
+  const response = await fetch(input, {
+    ...init,
+    credentials: "include",
+    cache: init.cache ?? "no-store",
+  })
+
+  if (response.status !== 401 || !retry) {
+    return response
+  }
+
+  const refreshed = await refreshSession()
+  if (!refreshed) {
+    return response
+  }
+
+  return apiFetch(input, init, false)
+}
+
+export function cleanupLegacyTokenStorage() {
+  if (typeof window === "undefined") return
+  clearLegacyAuthStorage()
+}
+
+export async function initSessionRefresh() {
+  if (typeof window === "undefined") return
+  await refreshSession()
+}

--- a/lib/me-service.ts
+++ b/lib/me-service.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from "@/lib/client-api"
 export type MeResponse = {
   authenticated: boolean
   sub: string
@@ -17,7 +18,7 @@ export class MeRequestError extends Error {
 }
 
 export async function getMe(): Promise<MeResponse> {
-  const response = await fetch("/api/profile/me", {
+  const response = await apiFetch("/api/profile/me", {
     method: "GET",
   })
 

--- a/lib/moneris/moneris-service.ts
+++ b/lib/moneris/moneris-service.ts
@@ -4,6 +4,7 @@
 
 import { MONERIS_API_CONFIG, MONERIS_CHECKOUT_SCRIPT_SRC } from '../config'; 
 import type { Address } from '../../components/ship-now/ship-now-form'; 
+import { apiFetch } from '@/lib/client-api'
 
 export interface MonerisBillingAddress {
     fullName: string;
@@ -131,7 +132,7 @@ export async function finalizeMonerisPayment(
 
 
 export async function finalizeMonerisPaymentViaApi(requestData: FinalizePaymentRequest): Promise<FinalizePaymentResponse> {
-  const res = await fetch('/api/payments/moneris/finalize', {
+  const res = await apiFetch('/api/payments/moneris/finalize', {
     method: 'POST',
     headers: {
       Accept: 'application/json',

--- a/lib/onboarding-service.ts
+++ b/lib/onboarding-service.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from "@/lib/client-api"
 import type { MeResponse } from "@/lib/me-service"
 
 export type OnboardingUserType = "INDIVIDUAL" | "ORGANIZATION"
@@ -38,7 +39,7 @@ export type OnboardingResult = {
 }
 
 export async function submitOnboarding(payload: OnboardingPayload): Promise<OnboardingResult> {
-  const response = await fetch("/api/profile/onboarding", {
+  const response = await apiFetch("/api/profile/onboarding", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/lib/order-service.ts
+++ b/lib/order-service.ts
@@ -1,38 +1,6 @@
 import type { ShippingOrder, Address } from "@/components/ship-now/ship-now-form"
 
-function getCookie(name: string): string | null {
-    if (typeof document === "undefined") return null
-
-    const value = `; ${document.cookie}`
-    const parts = value.split(`; ${name}=`)
-
-    if (parts.length === 2) {
-        return parts.pop()!.split(";").shift() || null
-    }
-
-    return null
-}
-
-function getAccessToken() {
-    return (
-        localStorage.getItem("maplexpress_access_token") ||
-        getCookie("accessToken") ||
-        getCookie("maplexpress_access_token") ||
-        ""
-    )
-}
-
-function getAuthHeaders(): Record<string, string> {
-    const accessToken = getAccessToken()
-
-    if (!accessToken) {
-        return {}
-    }
-
-    return {
-        Authorization: `Bearer ${accessToken}`,
-    }
-}
+import { apiFetch } from "@/lib/client-api"
 
 // Define the API response types based on the actual response format
 export interface OrderResponse {
@@ -292,24 +260,22 @@ function formatOrderRequest(order: ShippingOrder, userId: string, priorityDelive
 }
 
 export async function createOrder(payload: OrderRequest) {
-    return fetch("/api/orders", {
+    return apiFetch("/api/orders", {
         method: "POST",
         headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
         body: JSON.stringify(payload),
     })
 }
 
 export async function updateOrder(payload: OrderRequest) {
-    return fetch("/api/orders", {
+    return apiFetch("/api/orders", {
         method: "PUT",
         headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
         body: JSON.stringify(payload),
     })
@@ -337,11 +303,10 @@ function formatAddress(address: Address | null) {
 export async function getPaidOrdersByCustomer(customerId: string): Promise<OrderResponse[]> {
     const url = `/api/orders?customerId=${encodeURIComponent(customerId)}&paymentStatus=paid`
 
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
         headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
     })
 
@@ -365,11 +330,10 @@ export async function getClientOrders(filters: ClientOrdersFilters): Promise<Cli
     params.set("sortBy", filters.sortBy ?? "createdAt")
     params.set("sortDir", filters.sortDir ?? "desc")
 
-    const response = await fetch(`/api/orders?${params.toString()}`, {
+    const response = await apiFetch(`/api/orders?${params.toString()}`, {
         headers: {
             Accept: "application/json",
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
     })
 

--- a/lib/payment-service.ts
+++ b/lib/payment-service.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from "@/lib/client-api"
 import type { OrderResponse } from "@/lib/order-service"
 
 export interface BillingAddress {
@@ -66,7 +67,7 @@ export function buildCheckoutBillingAddress(orderData: OrderResponse): BillingAd
 }
 
 export async function checkoutPayment(payload: PaymentCheckoutRequest): Promise<PaymentCheckoutResponse> {
-  const response = await fetch("/api/payments/checkout", {
+  const response = await apiFetch("/api/payments/checkout", {
     method: "POST",
     headers: {
       Accept: "application/json",

--- a/lib/profile-service.ts
+++ b/lib/profile-service.ts
@@ -1,33 +1,10 @@
 import type { IndividualProfile, OrganizationProfile } from "@/types/profile"
-import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"   // ← updated path
-
-
-function getCookie(name: string): string | null {
-  if (typeof document === "undefined") return null
-  const value = `; ${document.cookie}`
-  const parts = value.split(`; ${name}=`)
-  if (parts.length === 2) {
-    return parts.pop()!.split(";").shift() || null
-  }
-  return null
-}
+import { apiFetch } from "@/lib/client-api"
 
 // Get individual profile
 export async function getIndividualProfile(userId: string): Promise<IndividualProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/profile/individual?userId=${userId}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  })
+  const response = await apiFetch(`/api/profile/individual?userId=${userId}`)
 
   if (!response.ok) {
     const error = await response.json()
@@ -39,20 +16,8 @@ export async function getIndividualProfile(userId: string): Promise<IndividualPr
 
 // Get organization profile
 export async function getOrganizationProfile(userId: string): Promise<OrganizationProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/profile/organization?userId=${userId}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  })
+  const response = await apiFetch(`/api/profile/organization?userId=${userId}`)
 
   if (!response.ok) {
     const error = await response.json()
@@ -66,22 +31,9 @@ export async function getOrganizationProfile(userId: string): Promise<Organizati
 export async function getIndividualProfileByEmail(
   email: string,
 ): Promise<IndividualProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(
+  const response = await apiFetch(
     `/api/profile/individual?email=${encodeURIComponent(email)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    },
   )
 
   if (!response.ok) {
@@ -97,22 +49,9 @@ export async function getIndividualProfileByEmail(
 export async function getOrganizationProfileByEmail(
   email: string,
 ): Promise<OrganizationProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(
+  const response = await apiFetch(
     `/api/profile/organization?email=${encodeURIComponent(email)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    },
   )
 
   if (!response.ok) {
@@ -129,20 +68,11 @@ export async function updateIndividualProfile(
   userId: string,
   profileData: Partial<IndividualProfile>,
 ): Promise<IndividualProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/profile/individual/update`, {
+  const response = await apiFetch(`/api/profile/individual/update`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
       userId,
@@ -163,20 +93,11 @@ export async function updateOrganizationProfile(
   userId: string,
   profileData: Partial<OrganizationProfile>,
 ): Promise<OrganizationProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/profile/organization/update`, {
+  const response = await apiFetch(`/api/profile/organization/update`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
       userId,
@@ -196,31 +117,13 @@ export async function updateIndividualInformation(
     userId: string,
     phone: string,
 ): Promise<IndividualProfile> {
-  const accessToken =
-      getCookie("accessToken") ||
-      getCookie("maplexpress_access_token") ||
-      localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  /** ------------------------------------------------------
-   * Build the full endpoint:
-   *   {PROFILE_SERVICE_URL}/profile/individual/user/{userId}
-   * ----------------------------------------------------- */
-  const endpoint = getEndpointUrl(
-      PROFILE_SERVICE_URL,
-      `/profile/individual/user/${encodeURIComponent(userId)}`,
-  )
-
-  const response = await fetch(endpoint, {
-    method: "PUT",
+  const response = await apiFetch(`/api/profile/individual/updateinformation`, {
+    method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({ phone }),
+    body: JSON.stringify({ userId, phone }),
   })
 
   const data = await response.json()
@@ -248,38 +151,26 @@ export async function updateOrganizationInformation(
       }
     },
 ): Promise<OrganizationProfile> {
-  const accessToken =
-      getCookie("accessToken") ||
-      getCookie("maplexpress_access_token") ||
-      localStorage.getItem("maplexpress_access_token")
-
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  /* Build full endpoint URL */
-  const endpoint = getEndpointUrl(
-      PROFILE_SERVICE_URL,
-      `/profile/organization/user/${encodeURIComponent(userId)}`,
-  )
 
   const payload = {
+    userId,
     registrationNumber: formData.registrationNumber || null,
     taxId: formData.taxID || null,
     industry: formData.industry || null,
     phone: formData.phone || null,
     websiteUrl: formData.website || null,
-    pointOfContactName: formData.pointOfContact.name || null,
-    pointOfContactPosition: formData.pointOfContact.position || null,
-    pointOfContactEmail: formData.pointOfContact.email || null,
-    pointOfContactPhone: formData.pointOfContact.phone || null,
+    pointOfContact: {
+      name: formData.pointOfContact.name || null,
+      position: formData.pointOfContact.position || null,
+      email: formData.pointOfContact.email || null,
+      phone: formData.pointOfContact.phone || null,
+    },
   }
 
-  const response = await fetch(endpoint, {
-    method: "PUT",
+  const response = await apiFetch(`/api/profile/organization/updateinformation`, {
+    method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   })
@@ -298,20 +189,11 @@ export async function changePassword(
   currentPassword: string,
   newPassword: string,
 ): Promise<{ success: boolean; message: string }> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/auth/change-password`, {
+  const response = await apiFetch(`/api/auth/change-password`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
       currentPassword,

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -1,0 +1,140 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { AUTH_REFRESH_URL } from "@/lib/config"
+
+export type AuthTokens = {
+  accessToken: string | null
+  idToken: string | null
+  refreshToken: string | null
+}
+
+type RefreshedTokens = {
+  accessToken: string
+  idToken?: string
+  refreshToken?: string
+}
+
+let refreshPromise: Promise<RefreshedTokens | null> | null = null
+
+export function getAuthTokensFromRequest(request: NextRequest): AuthTokens {
+  const authHeader = request.headers.get("authorization")
+  const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.split(" ")[1] : null
+
+  return {
+    accessToken:
+      bearerToken || request.cookies.get("maplexpress_access_token")?.value || request.cookies.get("accessToken")?.value || null,
+    idToken: request.cookies.get("maplexpress_id_token")?.value || null,
+    refreshToken: request.cookies.get("maplexpress_refresh_token")?.value || null,
+  }
+}
+
+export async function getAuthTokensFromCookies(): Promise<AuthTokens> {
+  const cookieStore = await cookies()
+  return {
+    accessToken: cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value || null,
+    idToken: cookieStore.get("maplexpress_id_token")?.value || null,
+    refreshToken: cookieStore.get("maplexpress_refresh_token")?.value || null,
+  }
+}
+
+
+
+type ServerAuthHeaderOptions = {
+  includeIdToken?: boolean
+  includeJsonContentType?: boolean
+}
+
+export async function getServerAuthHeaders(options: ServerAuthHeaderOptions = {}): Promise<Record<string, string> | null> {
+  const { includeIdToken = false, includeJsonContentType = false } = options
+  const tokens = await getAuthTokensFromCookies()
+
+  if (!tokens.accessToken) return null
+  if (includeIdToken && !tokens.idToken) return null
+
+  return {
+    Authorization: `Bearer ${tokens.accessToken}`,
+    ...(includeIdToken && tokens.idToken ? { "X-Id-Token": tokens.idToken } : {}),
+    ...(includeJsonContentType ? { "Content-Type": "application/json" } : {}),
+  }
+}
+async function refreshWithToken(refreshToken: string, request: NextRequest): Promise<RefreshedTokens | null> {
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      const response = await fetch(AUTH_REFRESH_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "Accept-Language": "application/json",
+          "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
+        },
+        body: JSON.stringify({ refreshToken }),
+      })
+
+      if (!response.ok) return null
+
+      const data = (await response.json()) as { accessToken?: string; refreshToken?: string; idToken?: string }
+      if (!data.accessToken) return null
+
+      return {
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken,
+        idToken: data.idToken,
+      }
+    })().finally(() => {
+      refreshPromise = null
+    })
+  }
+
+  return refreshPromise
+}
+
+export async function maybeRefreshTokens(tokens: AuthTokens, request: NextRequest) {
+  if (!tokens.refreshToken) return null
+  return refreshWithToken(tokens.refreshToken, request)
+}
+
+export function applyAuthCookies(response: NextResponse, tokens: RefreshedTokens) {
+  const isSecure = process.env.NODE_ENV === "production"
+  const accessTokenCookieOptions = {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 60 * 60,
+  }
+  const refreshTokenCookieOptions = {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 60 * 60 * 24 * 5,
+  }
+
+  response.cookies.set("maplexpress_access_token", tokens.accessToken, accessTokenCookieOptions)
+  response.cookies.set("accessToken", tokens.accessToken, accessTokenCookieOptions)
+
+  if (tokens.idToken) {
+    response.cookies.set("maplexpress_id_token", tokens.idToken, accessTokenCookieOptions)
+  }
+
+  if (tokens.refreshToken) {
+    response.cookies.set("maplexpress_refresh_token", tokens.refreshToken, refreshTokenCookieOptions)
+  }
+}
+
+export function clearAuthCookies(response: NextResponse) {
+  const isSecure = process.env.NODE_ENV === "production"
+  const cookieOptions = {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 0,
+  }
+
+  response.cookies.set("maplexpress_access_token", "", cookieOptions)
+  response.cookies.set("accessToken", "", cookieOptions)
+  response.cookies.set("maplexpress_refresh_token", "", cookieOptions)
+  response.cookies.set("maplexpress_id_token", "", cookieOptions)
+}

--- a/lib/serviceability-service.ts
+++ b/lib/serviceability-service.ts
@@ -1,7 +1,8 @@
+import { apiFetch } from "@/lib/client-api"
 import type { ServiceabilityResponse } from "@/lib/serviceability-server"
 
 export async function checkAddressServiceability(latitude: number, longitude: number): Promise<ServiceabilityResponse> {
-  const response = await fetch("/api/serviceability", {
+  const response = await apiFetch("/api/serviceability", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/lib/token-refresh.ts
+++ b/lib/token-refresh.ts
@@ -1,52 +1,26 @@
+import { cleanupLegacyTokenStorage } from "@/lib/client-api"
+
 /**
- * Utility function to refresh the access token using the refresh token
+ * Legacy-compatible refresh helper.
+ * Tokens are now stored in httpOnly cookies only.
  */
 export async function refreshAccessToken() {
   try {
-    const refreshToken = localStorage.getItem("maplexpress_refresh_token")
-
-    if (!refreshToken) {
-      throw new Error("No refresh token available")
-    }
-
-    // Call your refresh token endpoint
     const response = await fetch("/api/auth/refresh", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ refreshToken }),
+      credentials: "include",
+      cache: "no-store",
     })
-
-    const data = await response.json()
 
     if (!response.ok) {
       throw new Error("Failed to refresh token")
     }
 
-    // Update the stored tokens
-    localStorage.setItem("maplexpress_access_token", data.accessToken)
-
-    // If a new refresh token is provided, update it too
-    if (data.refreshToken) {
-      localStorage.setItem("maplexpress_refresh_token", data.refreshToken)
-    }
-
-    // Update user data if provided
-    if (data.tokenExpiration) {
-      const userData = JSON.parse(localStorage.getItem("maplexpress_user_data") || "{}")
-      userData.tokenExpiration = data.tokenExpiration
-      localStorage.setItem("maplexpress_user_data", JSON.stringify(userData))
-    }
-
-    return data.accessToken
+    cleanupLegacyTokenStorage()
+    return true
   } catch (error) {
-    // If refresh fails, log out the user
-    localStorage.removeItem("maplexpress_access_token")
-    localStorage.removeItem("maplexpress_refresh_token")
-    localStorage.removeItem("maplexpress_user_data")
-    window.location.href = "/" // Redirect to home page
-    throw error
+    cleanupLegacyTokenStorage()
+    console.error("Token refresh failed:", error)
+    return false
   }
 }
-


### PR DESCRIPTION
### Motivation
- Centralize authentication/token handling on the server to reduce duplication and ensure refresh logic is consistent across routes. 
- Provide an authenticated proxy for server routes to automatically retry with refreshed tokens and to set/clear httpOnly cookies. 
- Move client-side requests to a single `apiFetch` helper that supports automatic refresh to remove legacy localStorage/sessionStorage token usage. 

### Description
- Added `lib/server-auth.ts` to centralize cookie-based token extraction, refresh (`maybeRefreshTokens`), and cookie helpers `applyAuthCookies`/`clearAuthCookies`, and added `getServerAuthHeaders` for server use. 
- Implemented `lib/authenticated-proxy.ts` to proxy backend requests with automatic 401->refresh->retry behavior and to apply/clear auth cookies on responses. 
- Implemented client helpers in `lib/client-api.ts` (`apiFetch`, `initSessionRefresh`, `cleanupLegacyTokenStorage`) and wired them into client modules (`lib/me-service.ts`, `lib/onboarding-service.ts`, `lib/order-service.ts`, `lib/payment-service.ts`, `lib/serviceability-service.ts`, `lib/address-service.ts`, `lib/moneris/moneris-service.ts`, etc.). 
- Reworked API routes to use the proxy and server auth utilities (e.g. `app/api/*` routes now call `proxyWithAuthRetry`, `applyAuthCookies`, `clearAuthCookies`) and removed duplicated cookie/header handling across many files. 
- Updated admin/server-only services to use `getServerAuthHeaders` instead of reading cookies directly, and simplified token-refresh helper `lib/token-refresh.ts` to be legacy-compatible while migrating to cookie-first approach. 
- Updated client `AuthProvider` to initialize session refresh and cleanup legacy storage, and replaced direct `fetch` logout and profile calls with `apiFetch`. 

### Testing
- Ran TypeScript build/type-check (`tsc`) against the codebase with no type errors. 
- Ran the existing automated unit/integration test suite and linters; the test suite completed successfully. 
- Performed automated smoke checks against key auth flows (`POST /api/auth/login`, `POST /api/auth/refresh`, `POST /api/auth/logout`) and core proxied endpoints (`/api/orders`, `/api/profile/me`, `/api/payments/checkout`) which returned expected statuses in local environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda73eb3ec8329bf7b5ab516c6f158)