### PR TITLE
Centralize server auth, add authenticated proxy, and migrate client API to `apiFetch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,170 @@ Next.js has specific rules for environment variables:
 2. Use appropriate default values in `lib/config.ts` for development
 3. Always access environment variables through the exports in `lib/config.ts` rather than directly using `process.env`
 4. Ensure API keys have appropriate restrictions (domain, IP, etc.) for security
+
+---
+
+## MapleXpress Auth Architecture (Centralized, Production Standard)
+
+> This section is the source of truth for how authentication must work in this repository.
+> Any new API code MUST follow this model.
+
+### 1) Overall design
+
+MapleXpress FE uses AWS Cognito-issued JWTs with a **cookie-backed session model**.
+
+- Cognito provides access/refresh/id tokens through the login and refresh flows.
+- Tokens are stored in **httpOnly cookies** (canonical source).
+- Server-side code is responsible for token forwarding, refresh, retry, and cookie lifecycle.
+- Client-side code must rely on shared wrappers and never handle raw tokens.
+
+Why this is mandatory:
+- The project historically had mixed token paths (cookies + local/session storage + manual headers), which caused stale-token bugs and intermittent unauthorized behavior.
+- Centralization removes race conditions, inconsistent refresh behavior, and hard-to-debug “logged in but unauthorized” states.
+
+### 2) Canonical token flow
+
+#### Login
+1. Client calls `/api/auth/login`.
+2. Route performs Cognito auth.
+3. Route sets httpOnly cookies via centralized helpers (`applyAuthCookies`).
+4. Client stores only non-sensitive user/session metadata (never access token).
+
+#### Authenticated request flow
+1. Client uses `apiFetch` (not plain `fetch`) for authenticated internal API calls.
+2. Route handlers / server services use centralized server auth helpers.
+3. Access token is attached centrally.
+
+#### 401 refresh flow
+1. First authenticated request returns 401.
+2. Centralized refresh runs using refresh token.
+3. New cookies are persisted.
+4. Original request is retried once with fresh access token.
+5. If retry fails with 401, cookies/session are cleared and error is surfaced.
+
+#### Retry policy
+- Exactly one retry after refresh.
+- No infinite loops.
+- In-flight refresh is deduplicated to avoid refresh races.
+
+#### Logout cleanup
+- `/api/auth/logout` clears all auth cookies via centralized helper.
+- Client-side session metadata and any legacy token artifacts are cleared.
+
+#### Startup/proactive refresh
+- App startup attempts session refresh through centralized path.
+- Legacy token artifacts are cleaned during bootstrap.
+
+### 3) Server-side authenticated API pattern
+
+Use one of these centralized paths:
+
+- **Route-handler proxy pattern**: `proxyWithAuthRetry(request, options)` in `lib/authenticated-proxy.ts`.
+  - Use in `app/api/*` routes that proxy to backend services.
+  - Handles token retrieval, refresh, retry-once, and cookie updates/cleanup.
+
+- **Server utility pattern**: `authenticatedServerFetch(url, init, options)` in `lib/server-auth.ts`.
+  - Use in `lib/*` server utilities called from server components/routes.
+  - Handles cookie token retrieval, 401 refresh/retry-once, and best-effort cookie persistence/cleanup.
+
+Never do this manually in server code:
+- read auth cookies directly for token forwarding,
+- construct `Authorization` headers manually,
+- implement custom refresh logic,
+- duplicate retry logic.
+
+### 4) Client-side authenticated API pattern
+
+For authenticated internal FE calls (`/api/...`), always use:
+- `apiFetch` from `lib/client-api.ts`.
+
+`apiFetch` guarantees:
+- `credentials: include`,
+- centralized 401 handling,
+- refresh + retry-once,
+- refresh deduplication,
+- legacy token cleanup.
+
+Never do this manually in client code:
+- attach bearer tokens in headers,
+- read/write access tokens from storage,
+- call refresh endpoints with custom logic,
+- create duplicate wrappers around auth behavior.
+
+### 5) Forbidden anti-patterns
+
+The following are explicitly forbidden:
+
+1. `localStorage` / `sessionStorage` access token storage.
+2. Manual `Authorization: Bearer ...` construction outside centralized auth helpers.
+3. Route handlers that bypass `proxyWithAuthRetry` (for authenticated backend proxy calls).
+4. Server utilities that bypass `authenticatedServerFetch` (for authenticated backend calls).
+5. Custom per-file refresh implementations.
+6. Parallel/duplicate wrappers that diverge from centralized behavior.
+7. Ad-hoc cookie token parsing in feature code.
+
+### 6) How to add new API calls correctly
+
+#### A) New authenticated server-side route (`app/api/...`)
+1. Validate request input.
+2. Call `proxyWithAuthRetry(request, { method, url, body?, includeIdToken?, contentTypeJson? })`.
+3. Return proxied response payload/status.
+4. Do not parse cookies/tokens directly.
+5. Do not manually attach Authorization.
+
+#### B) New authenticated server utility (`lib/...`, server-only)
+1. Call `authenticatedServerFetch(url, init, { includeIdToken? })`.
+2. Handle `null` as unauthorized.
+3. Keep endpoint path/payload/response shaping local to the utility.
+4. Do not manually read cookies/tokens.
+
+#### C) New authenticated client call
+1. Use `apiFetch('/api/...', init)`.
+2. Keep payload/response mapping in service function.
+3. Do not add auth headers manually.
+4. Do not use direct refresh logic.
+
+#### D) New unauthenticated call
+- Use normal `fetch` (or a separate non-auth wrapper) only when endpoint is explicitly public/auth bootstrap flow.
+- Do not route public calls through auth retry wrappers unless endpoint is actually authenticated.
+
+#### E) Calls requiring id token
+- Route handler proxy: set `includeIdToken: true`.
+- Server utility fetch: set `{ includeIdToken: true }`.
+- Never pass id token manually from feature code.
+
+### 7) Debugging guidance
+
+When debugging unauthorized behavior:
+
+1. Confirm call path:
+   - Client auth call should use `apiFetch`.
+   - Route proxy should use `proxyWithAuthRetry`.
+   - Server utility should use `authenticatedServerFetch`.
+
+2. Check expected sequence:
+   - first request 401 -> refresh -> retry once.
+
+3. If repeated 401:
+   - refresh token may be expired/invalid,
+   - centralized helpers should clear auth cookies,
+   - client should transition to signed-out behavior.
+
+4. Check logs in:
+   - route handlers using proxy helper,
+   - auth refresh route,
+   - server-auth helper paths.
+
+5. Common failure modes:
+   - using plain `fetch` for authenticated endpoint,
+   - bypassing centralized helper in a new file,
+   - introducing manual bearer headers,
+   - stale legacy code reading token-like values from storage.
+
+### 8) Migration / historical context
+
+This repository previously had stale-token-prone mixed auth paths (manual headers, direct cookie/token reads, legacy storage artifacts, fragmented refresh behavior).
+
+The current model is intentionally centralized and strict.
+
+Future changes MUST preserve this standard and must not reintroduce legacy token handling patterns.

--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { AUTH_MICROSERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
@@ -10,36 +11,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: "All fields are required" }, { status: 400 })
     }
 
-    // Get the authorization header
-    const authHeader = request.headers.get("authorization")
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const token = authHeader.split(" ")[1]
-
-    // Use the endpoint from our centralized configuration
-    const changePasswordEndpoint = getEndpointUrl(AUTH_MICROSERVICE_URL, 'reset-password')
-
-    // Forward the request to your microservice
-    const response = await fetch(changePasswordEndpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(AUTH_MICROSERVICE_URL, "reset-password"),
       body: JSON.stringify({
         currentPassword,
         newPassword,
       }),
+      contentTypeJson: true,
     })
-
-    // Get the response data
-    const data = await response.json()
-
-    // Return the response
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Change password error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { decodeJwtPayload, cognitoRequest, getCognitoClientId } from "@/lib/cognito"
+import { applyAuthCookies } from "@/lib/server-auth"
 
 type CognitoInitiateAuthResponse = {
   AuthenticationResult?: {
@@ -80,26 +81,7 @@ export async function POST(request: NextRequest) {
       { status: 200 },
     )
 
-    const isSecure = process.env.NODE_ENV === "production"
-    const accessTokenCookieOptions = {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: "lax" as const,
-      path: "/",
-      maxAge: 60 * 60,
-    }
-    const refreshTokenCookieOptions = {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: "lax" as const,
-      path: "/",
-      maxAge: 60 * 60 * 24 * 5,
-    }
-
-    response.cookies.set("maplexpress_access_token", accessToken, accessTokenCookieOptions)
-    response.cookies.set("accessToken", accessToken, accessTokenCookieOptions)
-    response.cookies.set("maplexpress_id_token", idToken, accessTokenCookieOptions)
-    response.cookies.set("maplexpress_refresh_token", refreshToken, refreshTokenCookieOptions)
+    applyAuthCookies(response, { accessToken, refreshToken, idToken })
 
     return response
   } catch (error) {

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,20 +1,8 @@
 import { NextResponse } from "next/server"
+import { clearAuthCookies } from "@/lib/server-auth"
 
 export async function POST() {
   const response = NextResponse.json({ success: true }, { status: 200 })
-  const isSecure = process.env.NODE_ENV === "production"
-  const cookieOptions = {
-    httpOnly: true,
-    secure: isSecure,
-    sameSite: "lax" as const,
-    path: "/",
-    maxAge: 0,
-  }
-
-  response.cookies.set("maplexpress_access_token", "", cookieOptions)
-  response.cookies.set("accessToken", "", cookieOptions)
-  response.cookies.set("maplexpress_refresh_token", "", cookieOptions)
-  response.cookies.set("maplexpress_id_token", "", cookieOptions)
-
+  clearAuthCookies(response)
   return response
 }

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,37 +1,31 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { AUTH_REFRESH_URL } from "@/lib/config"
+import { maybeRefreshTokens, getAuthTokensFromRequest, applyAuthCookies, clearAuthCookies } from "@/lib/server-auth"
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json()
-    const { refreshToken } = body
+    const tokens = getAuthTokensFromRequest(request)
 
-    if (!refreshToken) {
-      return NextResponse.json({ message: "Refresh token is required" }, { status: 400 })
+    if (!tokens.refreshToken) {
+      const response = NextResponse.json({ message: "Refresh token is required" }, { status: 400 })
+      clearAuthCookies(response)
+      return response
     }
 
-    // Use the refresh URL from our centralized configuration
+    const refreshedTokens = await maybeRefreshTokens(tokens, request)
 
-    const response = await fetch(AUTH_REFRESH_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "Accept-Language": "application/json",
-        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
-      },
-      body: JSON.stringify({ refreshToken }),
-    })
-
-    const data = await response.json()
-
-    if (response.ok) {
-      return NextResponse.json(data, { status: 200 })
-    } else {
-      return NextResponse.json({ message: data.message || "Failed to refresh token" }, { status: response.status })
+    if (!refreshedTokens) {
+      const response = NextResponse.json({ message: "Failed to refresh token" }, { status: 401 })
+      clearAuthCookies(response)
+      return response
     }
+
+    const response = NextResponse.json({ success: true }, { status: 200 })
+    applyAuthCookies(response, refreshedTokens)
+    return response
   } catch (error) {
     console.error("Token refresh error:", error)
-    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
+    const response = NextResponse.json({ message: "Internal server error" }, { status: 500 })
+    clearAuthCookies(response)
+    return response
   }
 }

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,40 +1,15 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return (
-      request.cookies.get("accessToken")?.value ||
-      request.cookies.get("maplexpress_access_token")?.value ||
-      null
-    )
-  }
-
-  return authHeader.split(" ")[1]
-}
-
-function buildHeaders(token: string | null, contentType = false): HeadersInit {
-  return {
-    accept: "application/json",
-    ...(contentType ? { "Content-Type": "application/json" } : {}),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  }
-}
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function GET(request: NextRequest) {
   try {
-    const token = getToken(request)
     const search = request.nextUrl.search
-    const url = getEndpointUrl(ORDER_SERVICE_URL, `orders${search}`)
-
-    const response = await fetch(url, {
+    return await proxyWithAuthRetry(request, {
       method: "GET",
-      headers: buildHeaders(token, true),
+      url: getEndpointUrl(ORDER_SERVICE_URL, `orders${search}`),
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Get orders error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
@@ -43,18 +18,13 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const token = getToken(request)
     const body = await request.json()
-    const url = getEndpointUrl(ORDER_SERVICE_URL, "orders")
-
-    const response = await fetch(url, {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: buildHeaders(token, true),
+      url: getEndpointUrl(ORDER_SERVICE_URL, "orders"),
       body: JSON.stringify(body),
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Create order error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
@@ -63,18 +33,13 @@ export async function POST(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
-    const token = getToken(request)
     const body = await request.json()
-    const url = getEndpointUrl(ORDER_SERVICE_URL, "orders")
-
-    const response = await fetch(url, {
+    return await proxyWithAuthRetry(request, {
       method: "PUT",
-      headers: buildHeaders(token, true),
+      url: getEndpointUrl(ORDER_SERVICE_URL, "orders"),
       body: JSON.stringify(body),
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Update order error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -1,49 +1,16 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { PRICING_PAYMENT_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return (
-      request.cookies.get("accessToken")?.value ||
-      request.cookies.get("maplexpress_access_token")?.value ||
-      null
-    )
-  }
-
-  return authHeader.split(" ")[1]
-}
-
-function buildHeaders(token: string | null): HeadersInit {
-  return {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  }
-}
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const token = getToken(request)
     const body = await request.json()
-
-    const response = await fetch(getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "payments/checkout"), {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: buildHeaders(token),
+      url: getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "payments/checkout"),
       body: JSON.stringify(body),
-      cache: "no-store",
+      contentTypeJson: true,
     })
-
-    const raw = await response.text()
-    if (!raw) {
-      return NextResponse.json({ message: response.ok ? "Checkout request completed" : "Checkout request failed" }, { status: response.status })
-    }
-
-    try {
-      return NextResponse.json(JSON.parse(raw), { status: response.status })
-    } catch {
-      return NextResponse.json({ message: raw }, { status: response.status })
-    }
   } catch (error) {
     console.error("Checkout payment error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/payments/moneris/finalize/route.ts
+++ b/app/api/payments/moneris/finalize/route.ts
@@ -1,56 +1,17 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { MONERIS_API_CONFIG } from "@/lib/config"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return (
-      request.cookies.get("accessToken")?.value ||
-      request.cookies.get("maplexpress_access_token")?.value ||
-      null
-    )
-  }
-
-  return authHeader.split(" ")[1]
-}
-
-function buildHeaders(token: string | null): HeadersInit {
-  return {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  }
-}
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const token = getToken(request)
     const body = await request.json()
 
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const response = await fetch(`${MONERIS_API_CONFIG.baseUrl}finalize`, {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: buildHeaders(token),
+      url: `${MONERIS_API_CONFIG.baseUrl}finalize`,
       body: JSON.stringify(body),
-      cache: "no-store",
+      contentTypeJson: true,
     })
-
-    const raw = await response.text()
-    if (!raw) {
-      return NextResponse.json(
-        { message: response.ok ? "Payment finalized successfully" : "Failed to finalize payment" },
-        { status: response.status },
-      )
-    }
-
-    try {
-      return NextResponse.json(JSON.parse(raw), { status: response.status })
-    } catch {
-      return NextResponse.json({ message: raw }, { status: response.status })
-    }
   } catch (error) {
     console.error("Finalize payment error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/profile/address/[addressId]/route.ts
+++ b/app/api/profile/address/[addressId]/route.ts
@@ -1,19 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
-
-const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return (
-      request.cookies.get("maplexpress_access_token")?.value ||
-      request.cookies.get("accessToken")?.value ||
-      null
-    )
-  }
-
-  return authHeader.slice("Bearer ".length).trim() || null
-}
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 async function getJsonResponse(response: Response) {
   const text = await response.text()
@@ -36,26 +23,16 @@ export async function PATCH(
     const { addressId } = await params
     const addressData = await request.json()
 
-    const token = getToken(request)
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const endpoint = `${BASE_URL}/profile/addresses/${addressId}`
-
-    const response = await fetch(endpoint, {
+    const response = await proxyWithAuthRetry(request, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, `/profile/addresses/${addressId}`),
       body: JSON.stringify(addressData),
+      contentTypeJson: true,
     })
 
-    const data = await getJsonResponse(response)
+    const parsed = await getJsonResponse(response)
 
-    return NextResponse.json(data ?? {}, { status: response.status })
+    return NextResponse.json(parsed ?? {}, { status: response.status })
   } catch (error) {
     console.error("Update address error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
@@ -69,28 +46,18 @@ export async function DELETE(
   try {
     const { addressId } = await params
 
-    const token = getToken(request)
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const endpoint = `${BASE_URL}/profile/addresses/${addressId}`
-
-    const response = await fetch(endpoint, {
+    const response = await proxyWithAuthRetry(request, {
       method: "DELETE",
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, `/profile/addresses/${addressId}`),
     })
 
     if (response.status === 204) {
       return NextResponse.json({ success: true }, { status: 200 })
     }
 
-    const data = await getJsonResponse(response)
+    const parsed = await getJsonResponse(response)
 
-    return NextResponse.json(data ?? {}, { status: response.status })
+    return NextResponse.json(parsed ?? {}, { status: response.status })
   } catch (error) {
     console.error("Delete address error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/profile/address/route.ts
+++ b/app/api/profile/address/route.ts
@@ -1,20 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 import { checkAuthenticatedServiceability } from "@/lib/serviceability-server"
-
-const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return (
-      request.cookies.get("maplexpress_access_token")?.value ||
-      request.cookies.get("accessToken")?.value ||
-      null
-    )
-  }
-
-  return authHeader.slice("Bearer ".length).trim() || null
-}
 
 async function getJsonResponse(response: Response) {
   const text = await response.text()
@@ -29,51 +16,30 @@ async function getJsonResponse(response: Response) {
   }
 }
 
-// Get all addresses for a user
 export async function GET(request: NextRequest) {
   try {
-    const token = getToken(request)
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const endpoint = `${BASE_URL}/profile/addresses`
-
-    // Forward the request to your microservice
-    const response = await fetch(endpoint, {
+    const response = await proxyWithAuthRetry(request, {
       method: "GET",
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, "/profile/addresses"),
     })
 
-    // Get the response data
-    const data = await getJsonResponse(response)
-
-    // Return the response
-    return NextResponse.json(data ?? {}, { status: response.status })
+    const parsed = await getJsonResponse(response)
+    return NextResponse.json(parsed ?? {}, { status: response.status })
   } catch (error) {
     console.error("Get addresses error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }
 
-// Create a new address
 export async function POST(request: NextRequest) {
   try {
     const addressData = await request.json()
-
-    const token = getToken(request)
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
 
     const latitude = Number(addressData?.coordinates?.latitude)
     const longitude = Number(addressData?.coordinates?.longitude)
 
     if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
-      const serviceability = await checkAuthenticatedServiceability(latitude, longitude, token)
+      const serviceability = await checkAuthenticatedServiceability(latitude, longitude)
       if (!serviceability.serviceable) {
         return NextResponse.json(
           { message: serviceability.message || "Location is outside MapleX serviceable area." },
@@ -82,24 +48,15 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const endpoint = `${BASE_URL}/profile/addresses`
-
-    // Forward the request to your microservice
-    const response = await fetch(endpoint, {
+    const response = await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, "/profile/addresses"),
       body: JSON.stringify(addressData),
+      contentTypeJson: true,
     })
 
-    // Get the response data
-    const data = await getJsonResponse(response)
-
-    // Return the response
-    return NextResponse.json(data ?? {}, { status: response.status })
+    const parsed = await getJsonResponse(response)
+    return NextResponse.json(parsed ?? {}, { status: response.status })
   } catch (error) {
     console.error("Create address error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/profile/individual/route.ts
+++ b/app/api/profile/individual/route.ts
@@ -1,15 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { cookies } from "next/headers"
-
-const getBearerToken = async (request: NextRequest) => {
-  const authHeader = request.headers.get("authorization")
-  if (authHeader?.startsWith("Bearer ")) {
-    return authHeader.split(" ")[1]
-  }
-
-  const cookieStore = await cookies()
-  return cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-}
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,22 +11,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: "Missing required fields" }, { status: 400 })
     }
 
-    const token = await getBearerToken(request)
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/individual`
-
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, "/profile/individual"),
       body: JSON.stringify({
         userId,
         firstName,
@@ -44,10 +22,8 @@ export async function POST(request: NextRequest) {
         phone,
         type: "client",
       }),
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Create individual profile error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
@@ -64,25 +40,15 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ message: "userId or email is required" }, { status: 400 })
     }
 
-    const token = await getBearerToken(request)
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
+    const endpoint = userId
+      ? getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual?userId=${encodeURIComponent(userId)}`)
+      : getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual?email=${encodeURIComponent(email || "")}`)
 
-    const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = userId ? `${BASE_URL}/profile/individual?userId=${userId}` : `${BASE_URL}/profile/individual?email=${email}`
-
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "GET",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: endpoint,
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Get individual profile error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/profile/individual/update/route.ts
+++ b/app/api/profile/individual/update/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function PATCH(request: NextRequest) {
   try {
@@ -9,37 +11,14 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ message: "userId is required" }, { status: 400 })
     }
 
-    // Get the authorization header
-    const authHeader = request.headers.get("authorization")
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const token = authHeader.split(" ")[1]
-
-    // Use the correct base URL and endpoint
-    const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/individual/${userId}`
-
-    // Forward the request to your microservice
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual/${userId}`),
       body: JSON.stringify(profileData),
+      contentTypeJson: true,
     })
-
-    // Get the response data
-    const data = await response.json()
-
-    // Return the response
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Update individual profile error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }
-

--- a/app/api/profile/individual/updateinformation/route.ts
+++ b/app/api/profile/individual/updateinformation/route.ts
@@ -1,45 +1,24 @@
-import { type NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config";
+import { type NextRequest, NextResponse } from "next/server"
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { userId, phone } = body;
+    const body = await request.json()
+    const { userId, phone } = body
 
     if (!userId) {
-      return NextResponse.json({ message: "userId is required" }, { status: 400 });
+      return NextResponse.json({ message: "userId is required" }, { status: 400 })
     }
 
-    const cookieStore = cookies();
-    const token =
-      cookieStore.get("accessToken")?.value || cookieStore.get("maplexpress_access_token")?.value;
-
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
-    const endpoint = getEndpointUrl(
-      PROFILE_SERVICE_URL,
-      `/profile/individual/user/${userId}`,
-    );
-
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "Accept-Language": "application/json",
-        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual/user/${userId}`),
       body: JSON.stringify({ phone }),
-    });
-
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
+      contentTypeJson: true,
+    })
   } catch (error) {
-    console.error("Update individual information error:", error);
-    return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+    console.error("Update individual information error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }

--- a/app/api/profile/me/route.ts
+++ b/app/api/profile/me/route.ts
@@ -1,30 +1,14 @@
-import { NextResponse } from "next/server"
-import { cookies } from "next/headers"
+import { type NextRequest, NextResponse } from "next/server"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies()
-    const accessToken =
-      cookieStore.get("maplexpress_access_token")?.value ||
-      cookieStore.get("accessToken")?.value
-    const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-    if (!accessToken || !idToken) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/me"), {
+    return await proxyWithAuthRetry(request, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "X-Id-Token": idToken,
-      },
-      cache: "no-store",
+      url: getEndpointUrl(PROFILE_SERVICE_URL, "/me"),
+      includeIdToken: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Get /me error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/profile/onboarding/route.ts
+++ b/app/api/profile/onboarding/route.ts
@@ -1,35 +1,20 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { cookies } from "next/headers"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies()
-    const accessToken =
-      cookieStore.get("maplexpress_access_token")?.value ||
-      cookieStore.get("accessToken")?.value
-    const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-    if (!accessToken || !idToken) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
     const body = await request.json()
 
-    const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/onboarding"), {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-        "X-Id-Token": idToken,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, "/onboarding"),
       body: JSON.stringify(body),
+      includeIdToken: true,
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
-    console.error("Onboarding error:", error)
+    console.error("Onboarding route error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }

--- a/app/api/profile/organization/route.ts
+++ b/app/api/profile/organization/route.ts
@@ -1,15 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { cookies } from "next/headers"
-
-const getBearerToken = async (request: NextRequest) => {
-  const authHeader = request.headers.get("authorization")
-  if (authHeader?.startsWith("Bearer ")) {
-    return authHeader.split(" ")[1]
-  }
-
-  const cookieStore = await cookies()
-  return cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-}
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,22 +11,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: "Missing required fields" }, { status: 400 })
     }
 
-    const token = await getBearerToken(request)
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/organization`
-
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, "/profile/organization"),
       body: JSON.stringify({
         userId,
         name,
@@ -48,10 +26,8 @@ export async function POST(request: NextRequest) {
         website,
         pointOfContact,
       }),
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Create organization profile error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
@@ -68,27 +44,15 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ message: "userId or email is required" }, { status: 400 })
     }
 
-    const token = await getBearerToken(request)
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
     const endpoint = userId
-      ? `${BASE_URL}/profile/organization?userId=${userId}`
-      : `${BASE_URL}/profile/organization?email=${email}`
+      ? getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization?userId=${encodeURIComponent(userId)}`)
+      : getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization?email=${encodeURIComponent(email || "")}`)
 
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "GET",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: endpoint,
+      contentTypeJson: true,
     })
-
-    const data = await response.json()
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Get organization profile error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })

--- a/app/api/profile/organization/update/route.ts
+++ b/app/api/profile/organization/update/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function PATCH(request: NextRequest) {
   try {
@@ -9,37 +11,14 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ message: "userId is required" }, { status: 400 })
     }
 
-    // Get the authorization header
-    const authHeader = request.headers.get("authorization")
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-    }
-
-    const token = authHeader.split(" ")[1]
-
-    // Use the correct base URL and endpoint
-    const BASE_URL = process.env.NEXT_PUBLIC_PROFILE_SERVICE_URL || "http://localhost:30081/usermanagement"
-    const endpoint = `${BASE_URL}/profile/organization/${userId}`
-
-    // Forward the request to your microservice
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization/${userId}`),
       body: JSON.stringify(profileData),
+      contentTypeJson: true,
     })
-
-    // Get the response data
-    const data = await response.json()
-
-    // Return the response
-    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Update organization profile error:", error)
     return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }
-

--- a/app/api/profile/organization/updateinformation/route.ts
+++ b/app/api/profile/organization/updateinformation/route.ts
@@ -1,63 +1,34 @@
-import { type NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config";
+import { type NextRequest, NextResponse } from "next/server"
+import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const {
-      userId,
-      registrationNumber,
-      taxID,
-      industry,
-      phone,
-      website,
-      pointOfContact,
-    } = body;
+    const body = await request.json()
+    const { userId, registrationNumber, taxId, industry, phone, websiteUrl, pointOfContact } = body
 
     if (!userId) {
-      return NextResponse.json({ message: "userId is required" }, { status: 400 });
+      return NextResponse.json({ message: "userId is required" }, { status: 400 })
     }
 
-    const cookieStore = cookies();
-    const token =
-      cookieStore.get("accessToken")?.value || cookieStore.get("maplexpress_access_token")?.value;
-
-    if (!token) {
-      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
-    const endpoint = getEndpointUrl(
-      PROFILE_SERVICE_URL,
-      `/profile/organization/user/${userId}`,
-    );
-
-    const response = await fetch(endpoint, {
+    return await proxyWithAuthRetry(request, {
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "Accept-Language": "application/json",
-        "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
-        Authorization: `Bearer ${token}`,
-      },
+      url: getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization/user/${userId}`),
       body: JSON.stringify({
         registrationNumber,
-        taxId: taxID,
+        taxId,
         industry,
         phone,
-        websiteUrl: website,
+        websiteUrl,
         pointOfContactName: pointOfContact?.name,
         pointOfContactPosition: pointOfContact?.position,
         pointOfContactEmail: pointOfContact?.email,
         pointOfContactPhone: pointOfContact?.phone,
       }),
-    });
-
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
+      contentTypeJson: true,
+    })
   } catch (error) {
-    console.error("Update organization information error:", error);
-    return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+    console.error("Update organization information error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }

--- a/app/api/serviceability/route.ts
+++ b/app/api/serviceability/route.ts
@@ -1,37 +1,23 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { checkAuthenticatedServiceability } from "@/lib/serviceability-server"
-
-function getToken(request: NextRequest) {
-  const authHeader = request.headers.get("authorization")
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return request.cookies.get("accessToken")?.value || request.cookies.get("maplexpress_access_token")?.value || null
-  }
-
-  return authHeader.split(" ")[1]
-}
+import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
 
 export async function POST(request: NextRequest) {
-  const token = getToken(request)
-  if (!token) {
-    return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
-  }
-
-  const body = (await request.json().catch(() => ({}))) as { latitude?: number; longitude?: number }
-  const latitude = Number(body.latitude)
-  const longitude = Number(body.longitude)
-
-  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
-    return NextResponse.json({ message: "Valid latitude and longitude are required." }, { status: 400 })
-  }
-
   try {
-    const response = await checkAuthenticatedServiceability(latitude, longitude, token)
-    return NextResponse.json(response)
+    const { latitude, longitude } = await request.json()
+
+    if (typeof latitude !== "number" || typeof longitude !== "number") {
+      return NextResponse.json({ message: "Latitude and longitude are required" }, { status: 400 })
+    }
+
+    return await proxyWithAuthRetry(request, {
+      method: "POST",
+      url: getEndpointUrl(ORDER_SERVICE_URL, "/service-zones/check-serviceability"),
+      body: JSON.stringify({ latitude, longitude }),
+      contentTypeJson: true,
+    })
   } catch (error) {
-    return NextResponse.json(
-      { message: error instanceof Error ? error.message : "Unable to check serviceability right now." },
-      { status: 502 },
-    )
+    console.error("Serviceability route error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
   }
 }
-

--- a/components/admin/add-service-zone-form.tsx
+++ b/components/admin/add-service-zone-form.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import type { CreateServiceZoneResponse } from "@/types/admin-service-zones"
+import { apiFetch } from "@/lib/client-api"
 
 type FormState = {
   zoneName: string
@@ -152,7 +153,7 @@ export function AddServiceZoneForm() {
 
     try {
       setIsSubmitting(true)
-      const response = await fetch("/api/admin/service-zones", {
+      const response = await apiFetch("/api/admin/service-zones", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/components/admin/admin-pricing-manager.tsx
+++ b/components/admin/admin-pricing-manager.tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import type { CreatePricingModelRequest, PricingApiError, PricingModel } from "@/types/pricing"
+import { apiFetch } from "@/lib/client-api"
 
 const DEFAULT_DIMENSIONAL_WEIGHT_UNIT = "cm3/kg"
 
@@ -224,7 +225,7 @@ export function AdminPricingManager({ initialData, initialError }: Props) {
 
     try {
       setIsSubmitting(true)
-      const response = await fetch("/api/admin/pricing", {
+      const response = await apiFetch("/api/admin/pricing", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),

--- a/components/admin/driver-detail-actions.tsx
+++ b/components/admin/driver-detail-actions.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { DriverActionDialog } from "@/components/admin/driver-action-dialog"
+import { apiFetch } from "@/lib/client-api"
 
 type ActionKey = "approve" | "reject" | "suspend" | "unsuspend" | "terminate"
 
@@ -37,7 +38,7 @@ export function DriverDetailActions({ driverId, profileStatus }: { driverId: str
 
     try {
       setLoading(true)
-      const response = await fetch(`/api/admin/drivers/${driverId}/${currentAction}`, {
+      const response = await apiFetch(`/api/admin/drivers/${driverId}/${currentAction}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ reason, notes }),

--- a/components/admin/enable-pay-later-dialog.tsx
+++ b/components/admin/enable-pay-later-dialog.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { apiFetch } from "@/lib/client-api"
 
 export function EnablePayLaterDialog({
   ownerType,
@@ -44,7 +45,7 @@ export function EnablePayLaterDialog({
     try {
       setLoading(true)
       setReasonError(null)
-      const response = await fetch("/api/admin/customers/billing/pay-later/enable", {
+      const response = await apiFetch("/api/admin/customers/billing/pay-later/enable", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/components/admin/invite-driver-dialog.tsx
+++ b/components/admin/invite-driver-dialog.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import type { ApiErrorResponse } from "@/types/admin-drivers"
+import { apiFetch } from "@/lib/client-api"
 
 type FormState = {
   email: string
@@ -77,7 +78,7 @@ export function InviteDriverDialog() {
     try {
       setIsSubmitting(true)
 
-      const response = await fetch("/api/admin/drivers", {
+      const response = await apiFetch("/api/admin/drivers", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...form, email: normalizedEmail, companyName: "MAPLEX_EXPRESS_INC" }),

--- a/components/admin/profile-billing-card.tsx
+++ b/components/admin/profile-billing-card.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import { apiFetch } from "@/lib/client-api"
 
 function humanize(value?: string | null) {
   if (!value) return "—"
@@ -87,7 +88,7 @@ export function ProfileBillingCard({
     try {
       setLoading(true)
       setReasonError(null)
-      const response = await fetch("/api/admin/customers/billing/postpay/status", {
+      const response = await apiFetch("/api/admin/customers/billing/postpay/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/components/admin/service-zones-overview.tsx
+++ b/components/admin/service-zones-overview.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { apiFetch } from "@/lib/client-api"
 
 type Props = {
   initialZones: ServiceZone[]
@@ -101,7 +102,7 @@ export function ServiceZonesOverview({ initialZones }: Props) {
   const toggleActive = async (zone: ServiceZone) => {
     try {
       setPendingZoneId(zone.id)
-      const response = await fetch(`/api/admin/service-zones/${zone.id}/active`, {
+      const response = await apiFetch(`/api/admin/service-zones/${zone.id}/active`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",

--- a/lib/address-service.ts
+++ b/lib/address-service.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from "@/lib/client-api"
 import type { Address } from "@/types/address"
 
 type AddressInput = Omit<Address, "addressId" | "isPrimary"> & { isPrimary?: boolean }
@@ -18,7 +19,7 @@ async function getErrorMessage(response: Response, fallback: string) {
 
 // Get all addresses for a user
 export async function getAddresses(): Promise<Address[]> {
-  const response = await fetch("/api/profile/address")
+  const response = await apiFetch("/api/profile/address")
 
   if (!response.ok) {
     const message = await getErrorMessage(response, "Failed to fetch addresses")
@@ -32,7 +33,7 @@ export async function getAddresses(): Promise<Address[]> {
 export async function createAddress(
   addressData: AddressInput,
 ): Promise<Address> {
-  const response = await fetch("/api/profile/address", {
+  const response = await apiFetch("/api/profile/address", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -53,7 +54,7 @@ export async function updateAddress(
   addressId: string,
   addressData: AddressInput,
 ): Promise<Address> {
-  const response = await fetch(`/api/profile/address/${addressId}`, {
+  const response = await apiFetch(`/api/profile/address/${addressId}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
@@ -73,7 +74,7 @@ export async function updateAddress(
 export async function deleteAddress(
   addressId: string,
 ): Promise<boolean> {
-  const response = await fetch(`/api/profile/address/${addressId}`, {
+  const response = await apiFetch(`/api/profile/address/${addressId}`, {
     method: "DELETE",
   })
 

--- a/lib/admin-customer-billing-service.ts
+++ b/lib/admin-customer-billing-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 import type {
   AdminCustomerProfileListFilters,
   AdminEnablePayLaterRequest,
@@ -17,18 +17,6 @@ type ServiceResult<T> = {
   data: T | null
   error: ApiErrorResponse | null
   textError?: string | null
-}
-
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-  if (!accessToken || !idToken) return null
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "X-Id-Token": idToken,
-  }
 }
 
 function withJsonHeaders(headers: Record<string, string>) {
@@ -81,7 +69,7 @@ function normalizePageResponse<T>(payload: unknown, fallbackPage: number, fallba
 export async function listIndividualProfiles(
   filters: Omit<AdminCustomerProfileListFilters, "ownerType">,
 ): Promise<ServiceResult<PageResponse<IndividualProfile>>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const params = new URLSearchParams({ page: String(filters.page), size: String(filters.size) })
@@ -102,7 +90,7 @@ export async function listIndividualProfiles(
 }
 
 export async function getIndividualProfileById(id: string): Promise<ServiceResult<IndividualProfile>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual/${id}`), {
@@ -122,7 +110,7 @@ export async function getIndividualProfileById(id: string): Promise<ServiceResul
 export async function listOrganizationProfiles(
   filters: Omit<AdminCustomerProfileListFilters, "ownerType">,
 ): Promise<ServiceResult<PageResponse<OrganizationProfile>>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const params = new URLSearchParams({ page: String(filters.page), size: String(filters.size) })
@@ -149,7 +137,7 @@ export async function listOrganizationProfiles(
 }
 
 export async function getOrganizationProfileById(id: string): Promise<ServiceResult<OrganizationProfile>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization/${id}`), {
@@ -169,7 +157,7 @@ export async function getOrganizationProfileById(id: string): Promise<ServiceRes
 export async function enablePayLater(
   payload: AdminEnablePayLaterRequest,
 ): Promise<ServiceResult<ProfileBillingConfigurationResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/admin/profile/billing/pay-later/enable"), {
@@ -191,7 +179,7 @@ export async function enablePayLater(
 export async function updatePostpayStatus(
   payload: AdminUpdatePostpayStatusRequest,
 ): Promise<ServiceResult<ProfileBillingConfigurationResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/admin/profile/billing/postpay/status"), {

--- a/lib/admin-customer-billing-service.ts
+++ b/lib/admin-customer-billing-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-import { getServerAuthHeaders } from "@/lib/server-auth"
+import { authenticatedServerFetch } from "@/lib/server-auth"
 import type {
   AdminCustomerProfileListFilters,
   AdminEnablePayLaterRequest,
@@ -19,9 +19,9 @@ type ServiceResult<T> = {
   textError?: string | null
 }
 
-function withJsonHeaders(headers: Record<string, string>) {
+function withJsonHeaders(headers?: HeadersInit) {
   return {
-    ...headers,
+    ...(headers || {}),
     Accept: "application/json",
     "Content-Type": "application/json",
   }
@@ -69,16 +69,15 @@ function normalizePageResponse<T>(payload: unknown, fallbackPage: number, fallba
 export async function listIndividualProfiles(
   filters: Omit<AdminCustomerProfileListFilters, "ownerType">,
 ): Promise<ServiceResult<PageResponse<IndividualProfile>>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
-
   const params = new URLSearchParams({ page: String(filters.page), size: String(filters.size) })
   if (filters.email) params.set("email", filters.email)
   if (filters.userId) params.set("userId", filters.userId)
   if (filters.type) params.set("type", filters.type)
 
   const endpoint = `${getEndpointUrl(PROFILE_SERVICE_URL, "/profile/individual")}?${params.toString()}`
-  const response = await fetch(endpoint, { method: "GET", headers: withJsonHeaders(headers), cache: "no-store" })
+  const response = await authenticatedServerFetch(endpoint, { method: "GET", headers: withJsonHeaders() }, { includeIdToken: true })
+
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -90,14 +89,13 @@ export async function listIndividualProfiles(
 }
 
 export async function getIndividualProfileById(id: string): Promise<ServiceResult<IndividualProfile>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual/${id}`),
+    { method: "GET", headers: withJsonHeaders() },
+    { includeIdToken: true },
+  )
 
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/profile/individual/${id}`), {
-    method: "GET",
-    headers: withJsonHeaders(headers),
-    cache: "no-store",
-  })
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -110,9 +108,6 @@ export async function getIndividualProfileById(id: string): Promise<ServiceResul
 export async function listOrganizationProfiles(
   filters: Omit<AdminCustomerProfileListFilters, "ownerType">,
 ): Promise<ServiceResult<PageResponse<OrganizationProfile>>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
-
   const params = new URLSearchParams({ page: String(filters.page), size: String(filters.size) })
   if (filters.userId) params.set("userId", filters.userId)
   if (filters.email) params.set("email", filters.email)
@@ -121,7 +116,9 @@ export async function listOrganizationProfiles(
 
   const endpoint = `${getEndpointUrl(PROFILE_SERVICE_URL, "/profile/organization")}?${params.toString()}`
 
-  const response = await fetch(endpoint, { method: "GET", headers: withJsonHeaders(headers), cache: "no-store" })
+  const response = await authenticatedServerFetch(endpoint, { method: "GET", headers: withJsonHeaders() }, { includeIdToken: true })
+
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -137,14 +134,13 @@ export async function listOrganizationProfiles(
 }
 
 export async function getOrganizationProfileById(id: string): Promise<ServiceResult<OrganizationProfile>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization/${id}`),
+    { method: "GET", headers: withJsonHeaders() },
+    { includeIdToken: true },
+  )
 
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/profile/organization/${id}`), {
-    method: "GET",
-    headers: withJsonHeaders(headers),
-    cache: "no-store",
-  })
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -157,15 +153,17 @@ export async function getOrganizationProfileById(id: string): Promise<ServiceRes
 export async function enablePayLater(
   payload: AdminEnablePayLaterRequest,
 ): Promise<ServiceResult<ProfileBillingConfigurationResponse>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, "/admin/profile/billing/pay-later/enable"),
+    {
+      method: "POST",
+      headers: withJsonHeaders(),
+      body: JSON.stringify(payload),
+    },
+    { includeIdToken: true },
+  )
 
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/admin/profile/billing/pay-later/enable"), {
-    method: "POST",
-    headers: withJsonHeaders(headers),
-    body: JSON.stringify(payload),
-    cache: "no-store",
-  })
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -175,19 +173,20 @@ export async function enablePayLater(
   return { data: (await response.json()) as ProfileBillingConfigurationResponse, error: null, textError: null }
 }
 
-
 export async function updatePostpayStatus(
   payload: AdminUpdatePostpayStatusRequest,
 ): Promise<ServiceResult<ProfileBillingConfigurationResponse>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, "/admin/profile/billing/postpay/status"),
+    {
+      method: "PATCH",
+      headers: withJsonHeaders(),
+      body: JSON.stringify(payload),
+    },
+    { includeIdToken: true },
+  )
 
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/admin/profile/billing/postpay/status"), {
-    method: "PATCH",
-    headers: withJsonHeaders(headers),
-    body: JSON.stringify(payload),
-    cache: "no-store",
-  })
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)

--- a/lib/admin-drivers-service.ts
+++ b/lib/admin-drivers-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-import { getServerAuthHeaders } from "@/lib/server-auth"
+import { authenticatedServerFetch } from "@/lib/server-auth"
 import type {
   AdminDriversQuery,
   AdminDriversResponse,
@@ -40,11 +40,6 @@ async function parseError(response: Response): Promise<{ error: ApiErrorResponse
 }
 
 export async function getAdminDrivers(query: AdminDriversQuery): Promise<ServiceResult<AdminDriversResponse>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) {
-    return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
-  }
-
   const params = new URLSearchParams({ page: String(query.page), size: String(query.size) })
   if (query.email) params.set("email", query.email)
   if (query.name) params.set("name", query.name)
@@ -52,11 +47,15 @@ export async function getAdminDrivers(query: AdminDriversQuery): Promise<Service
   if (query.companyName) params.set("companyName", query.companyName)
   if (query.profileStatus) params.set("profileStatus", query.profileStatus)
 
-  const response = await fetch(`${getEndpointUrl(PROFILE_SERVICE_URL, "/admin/drivers")}?${params.toString()}`, {
-    method: "GET",
-    headers,
-    cache: "no-store",
-  })
+  const response = await authenticatedServerFetch(
+    `${getEndpointUrl(PROFILE_SERVICE_URL, "/admin/drivers")}?${params.toString()}`,
+    { method: "GET" },
+    { includeIdToken: true },
+  )
+
+  if (!response) {
+    return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
+  }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -67,16 +66,15 @@ export async function getAdminDrivers(query: AdminDriversQuery): Promise<Service
 }
 
 export async function getAdminDriverDetails(driverId: string): Promise<ServiceResult<DriverDetailsDto>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) {
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, `/admin/drivers/${driverId}`),
+    { method: "GET" },
+    { includeIdToken: true },
+  )
+
+  if (!response) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
-
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/admin/drivers/${driverId}`), {
-    method: "GET",
-    headers,
-    cache: "no-store",
-  })
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -91,20 +89,21 @@ export async function postAdminDriverAction(
   action: "approve" | "reject" | "suspend" | "unsuspend" | "terminate",
   payload: DriverActionRequestDto,
 ): Promise<ServiceResult<DriverActionResponseDto>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) {
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, `/admin/drivers/${driverId}/${action}`),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+    { includeIdToken: true },
+  )
+
+  if (!response) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
-
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/admin/drivers/${driverId}/${action}`), {
-    method: "POST",
-    headers: {
-      ...headers,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-    cache: "no-store",
-  })
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -118,20 +117,21 @@ export async function approveDriverLicense(
   driverId: string,
   payload: DriverLicenseApprovalRequestDto,
 ): Promise<ServiceResult<Record<string, unknown>>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) {
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, `/admin/drivers/${driverId}/driving-license/approve`),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+    { includeIdToken: true },
+  )
+
+  if (!response) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
-
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, `/admin/drivers/${driverId}/driving-license/approve`), {
-    method: "POST",
-    headers: {
-      ...headers,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-    cache: "no-store",
-  })
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -146,23 +146,21 @@ export async function approveDriverWorkEligibilityDocument(
   driverId: string,
   payload: DriverWorkEligibilityApprovalRequestDto,
 ): Promise<ServiceResult<Record<string, unknown>>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) {
-    return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
-  }
-
-  const response = await fetch(
+  const response = await authenticatedServerFetch(
     getEndpointUrl(PROFILE_SERVICE_URL, `/admin/drivers/${driverId}/work-eligibility-documents/approve`),
     {
       method: "POST",
       headers: {
-        ...headers,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(payload),
-      cache: "no-store",
     },
+    { includeIdToken: true },
   )
+
+  if (!response) {
+    return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
+  }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -174,20 +172,21 @@ export async function approveDriverWorkEligibilityDocument(
 }
 
 export async function inviteAdminDriver(payload: AdminInviteDriverRequest): Promise<ServiceResult<AdminInviteDriverResponse>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) {
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, "/admin/drivers"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+    { includeIdToken: true },
+  )
+
+  if (!response) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
-
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/admin/drivers"), {
-    method: "POST",
-    headers: {
-      ...headers,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-    cache: "no-store",
-  })
 
   if (!response.ok) {
     const parsed = await parseError(response)

--- a/lib/admin-drivers-service.ts
+++ b/lib/admin-drivers-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 import type {
   AdminDriversQuery,
   AdminDriversResponse,
@@ -19,18 +19,6 @@ type ServiceResult<T> = {
   data: T | null
   error: ApiErrorResponse | null
   textError?: string | null
-}
-
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-  if (!accessToken || !idToken) return null
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "X-Id-Token": idToken,
-  }
 }
 
 async function parseError(response: Response): Promise<{ error: ApiErrorResponse | null; textError: string | null }> {
@@ -52,7 +40,7 @@ async function parseError(response: Response): Promise<{ error: ApiErrorResponse
 }
 
 export async function getAdminDrivers(query: AdminDriversQuery): Promise<ServiceResult<AdminDriversResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -79,7 +67,7 @@ export async function getAdminDrivers(query: AdminDriversQuery): Promise<Service
 }
 
 export async function getAdminDriverDetails(driverId: string): Promise<ServiceResult<DriverDetailsDto>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -103,7 +91,7 @@ export async function postAdminDriverAction(
   action: "approve" | "reject" | "suspend" | "unsuspend" | "terminate",
   payload: DriverActionRequestDto,
 ): Promise<ServiceResult<DriverActionResponseDto>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -130,7 +118,7 @@ export async function approveDriverLicense(
   driverId: string,
   payload: DriverLicenseApprovalRequestDto,
 ): Promise<ServiceResult<Record<string, unknown>>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -158,7 +146,7 @@ export async function approveDriverWorkEligibilityDocument(
   driverId: string,
   payload: DriverWorkEligibilityApprovalRequestDto,
 ): Promise<ServiceResult<Record<string, unknown>>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
@@ -186,7 +174,7 @@ export async function approveDriverWorkEligibilityDocument(
 }
 
 export async function inviteAdminDriver(payload: AdminInviteDriverRequest): Promise<ServiceResult<AdminInviteDriverResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }

--- a/lib/admin-pricing-service.ts
+++ b/lib/admin-pricing-service.ts
@@ -1,28 +1,13 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { PRICING_PAYMENT_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 import type { CreatePricingModelRequest, PricingApiError, PricingModel } from "@/types/pricing"
 
 type ServiceResult<T> = {
   data: T | null
   error: PricingApiError | null
   textError?: string | null
-}
-
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-  if (!accessToken || !idToken) return null
-
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "X-Id-Token": idToken,
-    Accept: "application/json",
-    "Content-Type": "application/json",
-  }
 }
 
 async function parseError(response: Response): Promise<{ error: PricingApiError | null; textError: string | null }> {
@@ -44,7 +29,7 @@ async function parseError(response: Response): Promise<{ error: PricingApiError 
 }
 
 export async function getAdminPricingModels(): Promise<ServiceResult<PricingModel[]>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true, includeJsonContentType: true })
 
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
@@ -52,7 +37,7 @@ export async function getAdminPricingModels(): Promise<ServiceResult<PricingMode
 
   const response = await fetch(getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "/pricing"), {
     method: "GET",
-    headers,
+    headers: { ...headers, Accept: "application/json" },
     cache: "no-store",
   })
 
@@ -65,7 +50,7 @@ export async function getAdminPricingModels(): Promise<ServiceResult<PricingMode
 }
 
 export async function createAdminPricingModel(payload: CreatePricingModelRequest): Promise<ServiceResult<PricingModel>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true, includeJsonContentType: true })
 
   if (!headers) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
@@ -75,6 +60,7 @@ export async function createAdminPricingModel(payload: CreatePricingModelRequest
     method: "POST",
     headers: {
       ...headers,
+      Accept: "application/json",
     },
     body: JSON.stringify(payload),
     cache: "no-store",

--- a/lib/admin-pricing-service.ts
+++ b/lib/admin-pricing-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
 import { PRICING_PAYMENT_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-import { getServerAuthHeaders } from "@/lib/server-auth"
+import { authenticatedServerFetch } from "@/lib/server-auth"
 import type { CreatePricingModelRequest, PricingApiError, PricingModel } from "@/types/pricing"
 
 type ServiceResult<T> = {
@@ -29,17 +29,21 @@ async function parseError(response: Response): Promise<{ error: PricingApiError 
 }
 
 export async function getAdminPricingModels(): Promise<ServiceResult<PricingModel[]>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true, includeJsonContentType: true })
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "/pricing"),
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    },
+    { includeIdToken: true },
+  )
 
-  if (!headers) {
+  if (!response) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
-
-  const response = await fetch(getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "/pricing"), {
-    method: "GET",
-    headers: { ...headers, Accept: "application/json" },
-    cache: "no-store",
-  })
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -50,21 +54,22 @@ export async function getAdminPricingModels(): Promise<ServiceResult<PricingMode
 }
 
 export async function createAdminPricingModel(payload: CreatePricingModelRequest): Promise<ServiceResult<PricingModel>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true, includeJsonContentType: true })
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "/pricing"),
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+    { includeIdToken: true },
+  )
 
-  if (!headers) {
+  if (!response) {
     return { data: null, error: { status: "401", message: "Unauthorized" }, textError: null }
   }
-
-  const response = await fetch(getEndpointUrl(PRICING_PAYMENT_SERVICE_URL, "/pricing"), {
-    method: "POST",
-    headers: {
-      ...headers,
-      Accept: "application/json",
-    },
-    body: JSON.stringify(payload),
-    cache: "no-store",
-  })
 
   if (!response.ok) {
     const parsed = await parseError(response)

--- a/lib/admin-service-zones-service.ts
+++ b/lib/admin-service-zones-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
 import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-import { getServerAuthHeaders } from "@/lib/server-auth"
+import { authenticatedServerFetch } from "@/lib/server-auth"
 import type {
   CreateServiceZoneRequest,
   CreateServiceZoneResponse,
@@ -23,9 +23,9 @@ type ZoneFilters = {
   station?: string
 }
 
-function withJsonHeaders(headers: Record<string, string>) {
+function withJsonHeaders(headers?: HeadersInit) {
   return {
-    ...headers,
+    ...(headers || {}),
     Accept: "application/json",
     "Content-Type": "application/json",
   }
@@ -49,20 +49,22 @@ async function parseError(response: Response): Promise<{ error: ServiceZoneApiEr
 }
 
 export async function listServiceZones(filters: ZoneFilters = {}): Promise<ServiceResult<ListServiceZonesResponse>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
-
   const params = new URLSearchParams()
   if (typeof filters.active === "boolean") params.set("active", String(filters.active))
   if (filters.city) params.set("city", filters.city)
   if (filters.station) params.set("station", filters.station)
 
   const suffix = params.toString() ? `?${params.toString()}` : ""
-  const response = await fetch(getEndpointUrl(ORDER_SERVICE_URL, `/service-zones${suffix}`), {
-    method: "GET",
-    headers: withJsonHeaders(headers),
-    cache: "no-store",
-  })
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(ORDER_SERVICE_URL, `/service-zones${suffix}`),
+    {
+      method: "GET",
+      headers: withJsonHeaders(),
+    },
+    { includeIdToken: true },
+  )
+
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -73,15 +75,17 @@ export async function listServiceZones(filters: ZoneFilters = {}): Promise<Servi
 }
 
 export async function createServiceZone(payload: CreateServiceZoneRequest): Promise<ServiceResult<CreateServiceZoneResponse>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(ORDER_SERVICE_URL, "/service-zones"),
+    {
+      method: "POST",
+      headers: withJsonHeaders(),
+      body: JSON.stringify(payload),
+    },
+    { includeIdToken: true },
+  )
 
-  const response = await fetch(getEndpointUrl(ORDER_SERVICE_URL, "/service-zones"), {
-    method: "POST",
-    headers: withJsonHeaders(headers),
-    body: JSON.stringify(payload),
-    cache: "no-store",
-  })
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)
@@ -95,15 +99,17 @@ export async function toggleServiceZoneActive(
   id: string,
   payload: ToggleServiceZoneActiveRequest,
 ): Promise<ServiceResult<ToggleServiceZoneActiveResponse>> {
-  const headers = await getServerAuthHeaders({ includeIdToken: true })
-  if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(ORDER_SERVICE_URL, `/service-zones/${id}/active`),
+    {
+      method: "PATCH",
+      headers: withJsonHeaders(),
+      body: JSON.stringify(payload),
+    },
+    { includeIdToken: true },
+  )
 
-  const response = await fetch(getEndpointUrl(ORDER_SERVICE_URL, `/service-zones/${id}/active`), {
-    method: "PATCH",
-    headers: withJsonHeaders(headers),
-    body: JSON.stringify(payload),
-    cache: "no-store",
-  })
+  if (!response) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   if (!response.ok) {
     const parsed = await parseError(response)

--- a/lib/admin-service-zones-service.ts
+++ b/lib/admin-service-zones-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 import type {
   CreateServiceZoneRequest,
   CreateServiceZoneResponse,
@@ -21,18 +21,6 @@ type ZoneFilters = {
   active?: boolean
   city?: string
   station?: string
-}
-
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
-
-  if (!accessToken || !idToken) return null
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "X-Id-Token": idToken,
-  }
 }
 
 function withJsonHeaders(headers: Record<string, string>) {
@@ -61,7 +49,7 @@ async function parseError(response: Response): Promise<{ error: ServiceZoneApiEr
 }
 
 export async function listServiceZones(filters: ZoneFilters = {}): Promise<ServiceResult<ListServiceZonesResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const params = new URLSearchParams()
@@ -85,7 +73,7 @@ export async function listServiceZones(filters: ZoneFilters = {}): Promise<Servi
 }
 
 export async function createServiceZone(payload: CreateServiceZoneRequest): Promise<ServiceResult<CreateServiceZoneResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(ORDER_SERVICE_URL, "/service-zones"), {
@@ -107,7 +95,7 @@ export async function toggleServiceZoneActive(
   id: string,
   payload: ToggleServiceZoneActiveRequest,
 ): Promise<ServiceResult<ToggleServiceZoneActiveResponse>> {
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeIdToken: true })
   if (!headers) return { data: null, error: { status: "401", message: "Unauthorized" } }
 
   const response = await fetch(getEndpointUrl(ORDER_SERVICE_URL, `/service-zones/${id}/active`), {

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, useEffect, type ReactNode } from "react"
 import { getMe, MeRequestError, type MeResponse } from "@/lib/me-service"
 import { submitOnboarding, type OnboardingPayload } from "@/lib/onboarding-service"
+import { apiFetch, cleanupLegacyTokenStorage, initSessionRefresh } from "@/lib/client-api"
 
 // Update the User type to match your API response
 type User = {
@@ -132,6 +133,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   const clearSession = () => {
+    cleanupLegacyTokenStorage()
     localStorage.removeItem("maplexpress_user_data")
     localStorage.removeItem("maplexpress_me")
     localStorage.removeItem("maplexpress_individual_profile")
@@ -173,6 +175,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const checkAuth = async () => {
       try {
+        cleanupLegacyTokenStorage()
+        await initSessionRefresh()
         const userData = localStorage.getItem("maplexpress_user_data")
         const cachedMe = localStorage.getItem("maplexpress_me")
 
@@ -291,7 +295,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Update the logout function:
   const logout = async () => {
     try {
-      await fetch("/api/auth/logout", { method: "POST" })
+      await apiFetch("/api/auth/logout", { method: "POST" })
     } catch (error) {
       console.error("Logout error:", error)
     } finally {
@@ -352,7 +356,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     profileData: Omit<IndividualProfile, "id" | "status" | "email" | "createdAt" | "updatedAt">,
   ) => {
     try {
-      const response = await fetch("/api/profile/individual", {
+      const response = await apiFetch("/api/profile/individual", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -390,7 +394,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     profileData: Omit<OrganizationProfile, "id" | "status" | "createdAt" | "updatedAt">,
   ) => {
     try {
-      const response = await fetch("/api/profile/organization", {
+      const response = await apiFetch("/api/profile/organization", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -467,7 +471,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     try {
       if (currentUser.userType === "individualUser") {
-        const response = await fetch(
+        const response = await apiFetch(
           `/api/profile/individual?email=${encodeURIComponent(currentUser.email)}`,
           {},
         )
@@ -482,7 +486,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           )
         }
       } else if (currentUser.userType === "businessUser") {
-        const response = await fetch(
+        const response = await apiFetch(
           `/api/profile/organization?email=${encodeURIComponent(currentUser.email)}`,
           {},
         )

--- a/lib/authenticated-proxy.ts
+++ b/lib/authenticated-proxy.ts
@@ -1,0 +1,59 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { applyAuthCookies, clearAuthCookies, getAuthTokensFromRequest, maybeRefreshTokens } from "@/lib/server-auth"
+
+type ProxyOptions = {
+  url: string
+  method: string
+  body?: string
+  includeIdToken?: boolean
+  contentTypeJson?: boolean
+}
+
+function headersFor(accessToken: string | null, idToken?: string | null, contentTypeJson?: boolean): HeadersInit {
+  return {
+    accept: "application/json",
+    ...(contentTypeJson ? { "Content-Type": "application/json" } : {}),
+    ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    ...(idToken ? { "X-Id-Token": idToken } : {}),
+  }
+}
+
+export async function proxyWithAuthRetry(request: NextRequest, options: ProxyOptions) {
+  const tokens = getAuthTokensFromRequest(request)
+
+  const first = await fetch(options.url, {
+    method: options.method,
+    headers: headersFor(tokens.accessToken, options.includeIdToken ? tokens.idToken : null, options.contentTypeJson),
+    ...(options.body ? { body: options.body } : {}),
+    cache: "no-store",
+  })
+
+  if (first.status !== 401) {
+    const data = await first.json().catch(() => ({}))
+    return NextResponse.json(data, { status: first.status })
+  }
+
+  const refreshed = await maybeRefreshTokens(tokens, request)
+  if (!refreshed?.accessToken) {
+    const response = NextResponse.json({ message: "Unauthorized" }, { status: 401 })
+    clearAuthCookies(response)
+    return response
+  }
+
+  const second = await fetch(options.url, {
+    method: options.method,
+    headers: headersFor(refreshed.accessToken, options.includeIdToken ? refreshed.idToken || tokens.idToken : null, options.contentTypeJson),
+    ...(options.body ? { body: options.body } : {}),
+    cache: "no-store",
+  })
+
+  const payload = await second.json().catch(() => ({}))
+  const response = NextResponse.json(payload, { status: second.status })
+  applyAuthCookies(response, refreshed)
+
+  if (second.status === 401) {
+    clearAuthCookies(response)
+  }
+
+  return response
+}

--- a/lib/aws-integration-service.ts
+++ b/lib/aws-integration-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { AWS_INTEGRATION_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { getServerAuthHeaders } from "@/lib/server-auth"
 
 type PresignViewItem = {
   key: string
@@ -14,23 +14,11 @@ type PresignViewResponse = {
   items?: PresignViewItem[]
 }
 
-async function getAuthHeaders() {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-
-  if (!accessToken) return null
-
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    "Content-Type": "application/json",
-  }
-}
-
 export async function presignView(keys: string[]): Promise<Record<string, PresignViewItem>> {
   const uniqueKeys = Array.from(new Set(keys.filter(Boolean)))
   if (!uniqueKeys.length) return {}
 
-  const headers = await getAuthHeaders()
+  const headers = await getServerAuthHeaders({ includeJsonContentType: true })
   if (!headers) return {}
 
   const response = await fetch(getEndpointUrl(AWS_INTEGRATION_SERVICE_URL, "/v2/s3/presign/view"), {

--- a/lib/aws-integration-service.ts
+++ b/lib/aws-integration-service.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
 import { AWS_INTEGRATION_SERVICE_URL, getEndpointUrl } from "@/lib/config"
-import { getServerAuthHeaders } from "@/lib/server-auth"
+import { authenticatedServerFetch } from "@/lib/server-auth"
 
 type PresignViewItem = {
   key: string
@@ -18,17 +18,18 @@ export async function presignView(keys: string[]): Promise<Record<string, Presig
   const uniqueKeys = Array.from(new Set(keys.filter(Boolean)))
   if (!uniqueKeys.length) return {}
 
-  const headers = await getServerAuthHeaders({ includeJsonContentType: true })
-  if (!headers) return {}
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(AWS_INTEGRATION_SERVICE_URL, "/v2/s3/presign/view"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ keys: uniqueKeys }),
+    },
+  )
 
-  const response = await fetch(getEndpointUrl(AWS_INTEGRATION_SERVICE_URL, "/v2/s3/presign/view"), {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ keys: uniqueKeys }),
-    cache: "no-store",
-  })
-
-  if (!response.ok) return {}
+  if (!response || !response.ok) return {}
 
   const payload = (await response.json().catch(() => ({}))) as PresignViewResponse
   const map: Record<string, PresignViewItem> = {}

--- a/lib/client-api.ts
+++ b/lib/client-api.ts
@@ -1,0 +1,68 @@
+"use client"
+
+let refreshPromise: Promise<boolean> | null = null
+
+const clearLegacyAuthStorage = () => {
+  localStorage.removeItem("maplexpress_access_token")
+  localStorage.removeItem("maplexpress_refresh_token")
+  sessionStorage.removeItem("maplexpress_access_token")
+  sessionStorage.removeItem("maplexpress_refresh_token")
+}
+
+const refreshSession = async (): Promise<boolean> => {
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      try {
+        const response = await fetch("/api/auth/refresh", {
+          method: "POST",
+          credentials: "include",
+          cache: "no-store",
+        })
+
+        if (!response.ok) {
+          clearLegacyAuthStorage()
+          return false
+        }
+
+        clearLegacyAuthStorage()
+        return true
+      } catch {
+        clearLegacyAuthStorage()
+        return false
+      } finally {
+        refreshPromise = null
+      }
+    })()
+  }
+
+  return refreshPromise
+}
+
+export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}, retry = true): Promise<Response> {
+  const response = await fetch(input, {
+    ...init,
+    credentials: "include",
+    cache: init.cache ?? "no-store",
+  })
+
+  if (response.status !== 401 || !retry) {
+    return response
+  }
+
+  const refreshed = await refreshSession()
+  if (!refreshed) {
+    return response
+  }
+
+  return apiFetch(input, init, false)
+}
+
+export function cleanupLegacyTokenStorage() {
+  if (typeof window === "undefined") return
+  clearLegacyAuthStorage()
+}
+
+export async function initSessionRefresh() {
+  if (typeof window === "undefined") return
+  await refreshSession()
+}

--- a/lib/me-service.ts
+++ b/lib/me-service.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from "@/lib/client-api"
 export type MeResponse = {
   authenticated: boolean
   sub: string
@@ -17,7 +18,7 @@ export class MeRequestError extends Error {
 }
 
 export async function getMe(): Promise<MeResponse> {
-  const response = await fetch("/api/profile/me", {
+  const response = await apiFetch("/api/profile/me", {
     method: "GET",
   })
 

--- a/lib/moneris/moneris-service.ts
+++ b/lib/moneris/moneris-service.ts
@@ -4,6 +4,7 @@
 
 import { MONERIS_API_CONFIG, MONERIS_CHECKOUT_SCRIPT_SRC } from '../config'; 
 import type { Address } from '../../components/ship-now/ship-now-form'; 
+import { apiFetch } from '@/lib/client-api'
 
 export interface MonerisBillingAddress {
     fullName: string;
@@ -131,7 +132,7 @@ export async function finalizeMonerisPayment(
 
 
 export async function finalizeMonerisPaymentViaApi(requestData: FinalizePaymentRequest): Promise<FinalizePaymentResponse> {
-  const res = await fetch('/api/payments/moneris/finalize', {
+  const res = await apiFetch('/api/payments/moneris/finalize', {
     method: 'POST',
     headers: {
       Accept: 'application/json',

--- a/lib/onboarding-service.ts
+++ b/lib/onboarding-service.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from "@/lib/client-api"
 import type { MeResponse } from "@/lib/me-service"
 
 export type OnboardingUserType = "INDIVIDUAL" | "ORGANIZATION"
@@ -38,7 +39,7 @@ export type OnboardingResult = {
 }
 
 export async function submitOnboarding(payload: OnboardingPayload): Promise<OnboardingResult> {
-  const response = await fetch("/api/profile/onboarding", {
+  const response = await apiFetch("/api/profile/onboarding", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/lib/order-service.ts
+++ b/lib/order-service.ts
@@ -1,38 +1,6 @@
 import type { ShippingOrder, Address } from "@/components/ship-now/ship-now-form"
 
-function getCookie(name: string): string | null {
-    if (typeof document === "undefined") return null
-
-    const value = `; ${document.cookie}`
-    const parts = value.split(`; ${name}=`)
-
-    if (parts.length === 2) {
-        return parts.pop()!.split(";").shift() || null
-    }
-
-    return null
-}
-
-function getAccessToken() {
-    return (
-        localStorage.getItem("maplexpress_access_token") ||
-        getCookie("accessToken") ||
-        getCookie("maplexpress_access_token") ||
-        ""
-    )
-}
-
-function getAuthHeaders(): Record<string, string> {
-    const accessToken = getAccessToken()
-
-    if (!accessToken) {
-        return {}
-    }
-
-    return {
-        Authorization: `Bearer ${accessToken}`,
-    }
-}
+import { apiFetch } from "@/lib/client-api"
 
 // Define the API response types based on the actual response format
 export interface OrderResponse {
@@ -292,24 +260,22 @@ function formatOrderRequest(order: ShippingOrder, userId: string, priorityDelive
 }
 
 export async function createOrder(payload: OrderRequest) {
-    return fetch("/api/orders", {
+    return apiFetch("/api/orders", {
         method: "POST",
         headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
         body: JSON.stringify(payload),
     })
 }
 
 export async function updateOrder(payload: OrderRequest) {
-    return fetch("/api/orders", {
+    return apiFetch("/api/orders", {
         method: "PUT",
         headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
         body: JSON.stringify(payload),
     })
@@ -337,11 +303,10 @@ function formatAddress(address: Address | null) {
 export async function getPaidOrdersByCustomer(customerId: string): Promise<OrderResponse[]> {
     const url = `/api/orders?customerId=${encodeURIComponent(customerId)}&paymentStatus=paid`
 
-    const response = await fetch(url, {
+    const response = await apiFetch(url, {
         headers: {
             accept: "application/json",
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
     })
 
@@ -365,11 +330,10 @@ export async function getClientOrders(filters: ClientOrdersFilters): Promise<Cli
     params.set("sortBy", filters.sortBy ?? "createdAt")
     params.set("sortDir", filters.sortDir ?? "desc")
 
-    const response = await fetch(`/api/orders?${params.toString()}`, {
+    const response = await apiFetch(`/api/orders?${params.toString()}`, {
         headers: {
             Accept: "application/json",
             "Content-Type": "application/json",
-            ...getAuthHeaders(),
         },
     })
 

--- a/lib/payment-service.ts
+++ b/lib/payment-service.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from "@/lib/client-api"
 import type { OrderResponse } from "@/lib/order-service"
 
 export interface BillingAddress {
@@ -66,7 +67,7 @@ export function buildCheckoutBillingAddress(orderData: OrderResponse): BillingAd
 }
 
 export async function checkoutPayment(payload: PaymentCheckoutRequest): Promise<PaymentCheckoutResponse> {
-  const response = await fetch("/api/payments/checkout", {
+  const response = await apiFetch("/api/payments/checkout", {
     method: "POST",
     headers: {
       Accept: "application/json",

--- a/lib/profile-service.ts
+++ b/lib/profile-service.ts
@@ -1,33 +1,10 @@
 import type { IndividualProfile, OrganizationProfile } from "@/types/profile"
-import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"   // ← updated path
-
-
-function getCookie(name: string): string | null {
-  if (typeof document === "undefined") return null
-  const value = `; ${document.cookie}`
-  const parts = value.split(`; ${name}=`)
-  if (parts.length === 2) {
-    return parts.pop()!.split(";").shift() || null
-  }
-  return null
-}
+import { apiFetch } from "@/lib/client-api"
 
 // Get individual profile
 export async function getIndividualProfile(userId: string): Promise<IndividualProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/profile/individual?userId=${userId}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  })
+  const response = await apiFetch(`/api/profile/individual?userId=${userId}`)
 
   if (!response.ok) {
     const error = await response.json()
@@ -39,20 +16,8 @@ export async function getIndividualProfile(userId: string): Promise<IndividualPr
 
 // Get organization profile
 export async function getOrganizationProfile(userId: string): Promise<OrganizationProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/profile/organization?userId=${userId}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  })
+  const response = await apiFetch(`/api/profile/organization?userId=${userId}`)
 
   if (!response.ok) {
     const error = await response.json()
@@ -66,22 +31,9 @@ export async function getOrganizationProfile(userId: string): Promise<Organizati
 export async function getIndividualProfileByEmail(
   email: string,
 ): Promise<IndividualProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(
+  const response = await apiFetch(
     `/api/profile/individual?email=${encodeURIComponent(email)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    },
   )
 
   if (!response.ok) {
@@ -97,22 +49,9 @@ export async function getIndividualProfileByEmail(
 export async function getOrganizationProfileByEmail(
   email: string,
 ): Promise<OrganizationProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(
+  const response = await apiFetch(
     `/api/profile/organization?email=${encodeURIComponent(email)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    },
   )
 
   if (!response.ok) {
@@ -129,20 +68,11 @@ export async function updateIndividualProfile(
   userId: string,
   profileData: Partial<IndividualProfile>,
 ): Promise<IndividualProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/profile/individual/update`, {
+  const response = await apiFetch(`/api/profile/individual/update`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
       userId,
@@ -163,20 +93,11 @@ export async function updateOrganizationProfile(
   userId: string,
   profileData: Partial<OrganizationProfile>,
 ): Promise<OrganizationProfile> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/profile/organization/update`, {
+  const response = await apiFetch(`/api/profile/organization/update`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
       userId,
@@ -196,31 +117,13 @@ export async function updateIndividualInformation(
     userId: string,
     phone: string,
 ): Promise<IndividualProfile> {
-  const accessToken =
-      getCookie("accessToken") ||
-      getCookie("maplexpress_access_token") ||
-      localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  /** ------------------------------------------------------
-   * Build the full endpoint:
-   *   {PROFILE_SERVICE_URL}/profile/individual/user/{userId}
-   * ----------------------------------------------------- */
-  const endpoint = getEndpointUrl(
-      PROFILE_SERVICE_URL,
-      `/profile/individual/user/${encodeURIComponent(userId)}`,
-  )
-
-  const response = await fetch(endpoint, {
-    method: "PUT",
+  const response = await apiFetch(`/api/profile/individual/updateinformation`, {
+    method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({ phone }),
+    body: JSON.stringify({ userId, phone }),
   })
 
   const data = await response.json()
@@ -248,38 +151,26 @@ export async function updateOrganizationInformation(
       }
     },
 ): Promise<OrganizationProfile> {
-  const accessToken =
-      getCookie("accessToken") ||
-      getCookie("maplexpress_access_token") ||
-      localStorage.getItem("maplexpress_access_token")
-
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  /* Build full endpoint URL */
-  const endpoint = getEndpointUrl(
-      PROFILE_SERVICE_URL,
-      `/profile/organization/user/${encodeURIComponent(userId)}`,
-  )
 
   const payload = {
+    userId,
     registrationNumber: formData.registrationNumber || null,
     taxId: formData.taxID || null,
     industry: formData.industry || null,
     phone: formData.phone || null,
     websiteUrl: formData.website || null,
-    pointOfContactName: formData.pointOfContact.name || null,
-    pointOfContactPosition: formData.pointOfContact.position || null,
-    pointOfContactEmail: formData.pointOfContact.email || null,
-    pointOfContactPhone: formData.pointOfContact.phone || null,
+    pointOfContact: {
+      name: formData.pointOfContact.name || null,
+      position: formData.pointOfContact.position || null,
+      email: formData.pointOfContact.email || null,
+      phone: formData.pointOfContact.phone || null,
+    },
   }
 
-  const response = await fetch(endpoint, {
-    method: "PUT",
+  const response = await apiFetch(`/api/profile/organization/updateinformation`, {
+    method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify(payload),
   })
@@ -298,20 +189,11 @@ export async function changePassword(
   currentPassword: string,
   newPassword: string,
 ): Promise<{ success: boolean; message: string }> {
-  const accessToken =
-    getCookie("accessToken") ||
-    getCookie("maplexpress_access_token") ||
-    localStorage.getItem("maplexpress_access_token")
 
-  if (!accessToken) {
-    throw new Error("Not authenticated")
-  }
-
-  const response = await fetch(`/api/auth/change-password`, {
+  const response = await apiFetch(`/api/auth/change-password`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({
       currentPassword,

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -14,7 +14,59 @@ type RefreshedTokens = {
   refreshToken?: string
 }
 
+type ServerAuthHeaderOptions = {
+  includeIdToken?: boolean
+  includeJsonContentType?: boolean
+}
+
+type AuthenticatedServerFetchOptions = {
+  includeIdToken?: boolean
+}
+
 let refreshPromise: Promise<RefreshedTokens | null> | null = null
+
+const ACCESS_TOKEN_MAX_AGE = 60 * 60
+const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 5
+
+function getCookieOptions(maxAge: number) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge,
+  }
+}
+
+async function persistCookies(tokens: { accessToken: string; idToken?: string; refreshToken?: string }) {
+  try {
+    const cookieStore = await cookies()
+    cookieStore.set("maplexpress_access_token", tokens.accessToken, getCookieOptions(ACCESS_TOKEN_MAX_AGE))
+    cookieStore.set("accessToken", tokens.accessToken, getCookieOptions(ACCESS_TOKEN_MAX_AGE))
+
+    if (tokens.idToken) {
+      cookieStore.set("maplexpress_id_token", tokens.idToken, getCookieOptions(ACCESS_TOKEN_MAX_AGE))
+    }
+
+    if (tokens.refreshToken) {
+      cookieStore.set("maplexpress_refresh_token", tokens.refreshToken, getCookieOptions(REFRESH_TOKEN_MAX_AGE))
+    }
+  } catch {
+    // cookie mutations are not available in all server contexts (e.g. some RSC renders)
+  }
+}
+
+async function clearCookiesInStore() {
+  try {
+    const cookieStore = await cookies()
+    cookieStore.set("maplexpress_access_token", "", getCookieOptions(0))
+    cookieStore.set("accessToken", "", getCookieOptions(0))
+    cookieStore.set("maplexpress_refresh_token", "", getCookieOptions(0))
+    cookieStore.set("maplexpress_id_token", "", getCookieOptions(0))
+  } catch {
+    // cookie mutations are not available in all server contexts
+  }
+}
 
 export function getAuthTokensFromRequest(request: NextRequest): AuthTokens {
   const authHeader = request.headers.get("authorization")
@@ -37,27 +89,7 @@ export async function getAuthTokensFromCookies(): Promise<AuthTokens> {
   }
 }
 
-
-
-type ServerAuthHeaderOptions = {
-  includeIdToken?: boolean
-  includeJsonContentType?: boolean
-}
-
-export async function getServerAuthHeaders(options: ServerAuthHeaderOptions = {}): Promise<Record<string, string> | null> {
-  const { includeIdToken = false, includeJsonContentType = false } = options
-  const tokens = await getAuthTokensFromCookies()
-
-  if (!tokens.accessToken) return null
-  if (includeIdToken && !tokens.idToken) return null
-
-  return {
-    Authorization: `Bearer ${tokens.accessToken}`,
-    ...(includeIdToken && tokens.idToken ? { "X-Id-Token": tokens.idToken } : {}),
-    ...(includeJsonContentType ? { "Content-Type": "application/json" } : {}),
-  }
-}
-async function refreshWithToken(refreshToken: string, request: NextRequest): Promise<RefreshedTokens | null> {
+async function refreshWithToken(refreshToken: string, forwardedIp?: string | null): Promise<RefreshedTokens | null> {
   if (!refreshPromise) {
     refreshPromise = (async () => {
       const response = await fetch(AUTH_REFRESH_URL, {
@@ -66,7 +98,7 @@ async function refreshWithToken(refreshToken: string, request: NextRequest): Pro
           "Content-Type": "application/json",
           Accept: "application/json",
           "Accept-Language": "application/json",
-          "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
+          "X-Real-IP": forwardedIp || "127.0.0.1",
         },
         body: JSON.stringify({ refreshToken }),
       })
@@ -91,50 +123,81 @@ async function refreshWithToken(refreshToken: string, request: NextRequest): Pro
 
 export async function maybeRefreshTokens(tokens: AuthTokens, request: NextRequest) {
   if (!tokens.refreshToken) return null
-  return refreshWithToken(tokens.refreshToken, request)
+  return refreshWithToken(tokens.refreshToken, request.headers.get("x-forwarded-for"))
+}
+
+export async function getServerAuthHeaders(options: ServerAuthHeaderOptions = {}): Promise<Record<string, string> | null> {
+  const { includeIdToken = false, includeJsonContentType = false } = options
+  const tokens = await getAuthTokensFromCookies()
+
+  if (!tokens.accessToken) return null
+  if (includeIdToken && !tokens.idToken) return null
+
+  return {
+    Authorization: `Bearer ${tokens.accessToken}`,
+    ...(includeIdToken && tokens.idToken ? { "X-Id-Token": tokens.idToken } : {}),
+    ...(includeJsonContentType ? { "Content-Type": "application/json" } : {}),
+  }
+}
+
+export async function authenticatedServerFetch(
+  input: string,
+  init: RequestInit = {},
+  options: AuthenticatedServerFetchOptions = {},
+): Promise<Response | null> {
+  const { includeIdToken = false } = options
+  const tokens = await getAuthTokensFromCookies()
+
+  if (!tokens.accessToken) return null
+  if (includeIdToken && !tokens.idToken) return null
+
+  const baseHeaders = new Headers(init.headers || {})
+  baseHeaders.set("Authorization", `Bearer ${tokens.accessToken}`)
+  if (includeIdToken && tokens.idToken) {
+    baseHeaders.set("X-Id-Token", tokens.idToken)
+  }
+
+  const first = await fetch(input, { ...init, headers: baseHeaders, cache: init.cache ?? "no-store" })
+  if (first.status !== 401) return first
+
+  const refreshed = tokens.refreshToken ? await refreshWithToken(tokens.refreshToken) : null
+  if (!refreshed?.accessToken) {
+    await clearCookiesInStore()
+    return first
+  }
+
+  await persistCookies(refreshed)
+
+  const retryHeaders = new Headers(init.headers || {})
+  retryHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`)
+  if (includeIdToken && (refreshed.idToken || tokens.idToken)) {
+    retryHeaders.set("X-Id-Token", refreshed.idToken || tokens.idToken || "")
+  }
+
+  const second = await fetch(input, { ...init, headers: retryHeaders, cache: init.cache ?? "no-store" })
+  if (second.status === 401) {
+    await clearCookiesInStore()
+  }
+
+  return second
 }
 
 export function applyAuthCookies(response: NextResponse, tokens: RefreshedTokens) {
-  const isSecure = process.env.NODE_ENV === "production"
-  const accessTokenCookieOptions = {
-    httpOnly: true,
-    secure: isSecure,
-    sameSite: "lax" as const,
-    path: "/",
-    maxAge: 60 * 60,
-  }
-  const refreshTokenCookieOptions = {
-    httpOnly: true,
-    secure: isSecure,
-    sameSite: "lax" as const,
-    path: "/",
-    maxAge: 60 * 60 * 24 * 5,
-  }
-
-  response.cookies.set("maplexpress_access_token", tokens.accessToken, accessTokenCookieOptions)
-  response.cookies.set("accessToken", tokens.accessToken, accessTokenCookieOptions)
+  response.cookies.set("maplexpress_access_token", tokens.accessToken, getCookieOptions(ACCESS_TOKEN_MAX_AGE))
+  response.cookies.set("accessToken", tokens.accessToken, getCookieOptions(ACCESS_TOKEN_MAX_AGE))
 
   if (tokens.idToken) {
-    response.cookies.set("maplexpress_id_token", tokens.idToken, accessTokenCookieOptions)
+    response.cookies.set("maplexpress_id_token", tokens.idToken, getCookieOptions(ACCESS_TOKEN_MAX_AGE))
   }
 
   if (tokens.refreshToken) {
-    response.cookies.set("maplexpress_refresh_token", tokens.refreshToken, refreshTokenCookieOptions)
+    response.cookies.set("maplexpress_refresh_token", tokens.refreshToken, getCookieOptions(REFRESH_TOKEN_MAX_AGE))
   }
 }
 
 export function clearAuthCookies(response: NextResponse) {
-  const isSecure = process.env.NODE_ENV === "production"
-  const cookieOptions = {
-    httpOnly: true,
-    secure: isSecure,
-    sameSite: "lax" as const,
-    path: "/",
-    maxAge: 0,
-  }
-
-  response.cookies.set("maplexpress_access_token", "", cookieOptions)
-  response.cookies.set("accessToken", "", cookieOptions)
-  response.cookies.set("maplexpress_refresh_token", "", cookieOptions)
-  response.cookies.set("maplexpress_id_token", "", cookieOptions)
+  response.cookies.set("maplexpress_access_token", "", getCookieOptions(0))
+  response.cookies.set("accessToken", "", getCookieOptions(0))
+  response.cookies.set("maplexpress_refresh_token", "", getCookieOptions(0))
+  response.cookies.set("maplexpress_id_token", "", getCookieOptions(0))
 }

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -1,0 +1,140 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { AUTH_REFRESH_URL } from "@/lib/config"
+
+export type AuthTokens = {
+  accessToken: string | null
+  idToken: string | null
+  refreshToken: string | null
+}
+
+type RefreshedTokens = {
+  accessToken: string
+  idToken?: string
+  refreshToken?: string
+}
+
+let refreshPromise: Promise<RefreshedTokens | null> | null = null
+
+export function getAuthTokensFromRequest(request: NextRequest): AuthTokens {
+  const authHeader = request.headers.get("authorization")
+  const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.split(" ")[1] : null
+
+  return {
+    accessToken:
+      bearerToken || request.cookies.get("maplexpress_access_token")?.value || request.cookies.get("accessToken")?.value || null,
+    idToken: request.cookies.get("maplexpress_id_token")?.value || null,
+    refreshToken: request.cookies.get("maplexpress_refresh_token")?.value || null,
+  }
+}
+
+export async function getAuthTokensFromCookies(): Promise<AuthTokens> {
+  const cookieStore = await cookies()
+  return {
+    accessToken: cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value || null,
+    idToken: cookieStore.get("maplexpress_id_token")?.value || null,
+    refreshToken: cookieStore.get("maplexpress_refresh_token")?.value || null,
+  }
+}
+
+
+
+type ServerAuthHeaderOptions = {
+  includeIdToken?: boolean
+  includeJsonContentType?: boolean
+}
+
+export async function getServerAuthHeaders(options: ServerAuthHeaderOptions = {}): Promise<Record<string, string> | null> {
+  const { includeIdToken = false, includeJsonContentType = false } = options
+  const tokens = await getAuthTokensFromCookies()
+
+  if (!tokens.accessToken) return null
+  if (includeIdToken && !tokens.idToken) return null
+
+  return {
+    Authorization: `Bearer ${tokens.accessToken}`,
+    ...(includeIdToken && tokens.idToken ? { "X-Id-Token": tokens.idToken } : {}),
+    ...(includeJsonContentType ? { "Content-Type": "application/json" } : {}),
+  }
+}
+async function refreshWithToken(refreshToken: string, request: NextRequest): Promise<RefreshedTokens | null> {
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      const response = await fetch(AUTH_REFRESH_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "Accept-Language": "application/json",
+          "X-Real-IP": request.headers.get("x-forwarded-for") || "127.0.0.1",
+        },
+        body: JSON.stringify({ refreshToken }),
+      })
+
+      if (!response.ok) return null
+
+      const data = (await response.json()) as { accessToken?: string; refreshToken?: string; idToken?: string }
+      if (!data.accessToken) return null
+
+      return {
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken,
+        idToken: data.idToken,
+      }
+    })().finally(() => {
+      refreshPromise = null
+    })
+  }
+
+  return refreshPromise
+}
+
+export async function maybeRefreshTokens(tokens: AuthTokens, request: NextRequest) {
+  if (!tokens.refreshToken) return null
+  return refreshWithToken(tokens.refreshToken, request)
+}
+
+export function applyAuthCookies(response: NextResponse, tokens: RefreshedTokens) {
+  const isSecure = process.env.NODE_ENV === "production"
+  const accessTokenCookieOptions = {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 60 * 60,
+  }
+  const refreshTokenCookieOptions = {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 60 * 60 * 24 * 5,
+  }
+
+  response.cookies.set("maplexpress_access_token", tokens.accessToken, accessTokenCookieOptions)
+  response.cookies.set("accessToken", tokens.accessToken, accessTokenCookieOptions)
+
+  if (tokens.idToken) {
+    response.cookies.set("maplexpress_id_token", tokens.idToken, accessTokenCookieOptions)
+  }
+
+  if (tokens.refreshToken) {
+    response.cookies.set("maplexpress_refresh_token", tokens.refreshToken, refreshTokenCookieOptions)
+  }
+}
+
+export function clearAuthCookies(response: NextResponse) {
+  const isSecure = process.env.NODE_ENV === "production"
+  const cookieOptions = {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 0,
+  }
+
+  response.cookies.set("maplexpress_access_token", "", cookieOptions)
+  response.cookies.set("accessToken", "", cookieOptions)
+  response.cookies.set("maplexpress_refresh_token", "", cookieOptions)
+  response.cookies.set("maplexpress_id_token", "", cookieOptions)
+}

--- a/lib/server-me.ts
+++ b/lib/server-me.ts
@@ -1,28 +1,17 @@
 import "server-only"
 
-import { cookies } from "next/headers"
 import { PROFILE_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { authenticatedServerFetch } from "@/lib/server-auth"
 import type { MeResponse } from "@/lib/me-service"
 
 export async function getServerMe(): Promise<MeResponse | null> {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get("maplexpress_access_token")?.value || cookieStore.get("accessToken")?.value
-  const idToken = cookieStore.get("maplexpress_id_token")?.value
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(PROFILE_SERVICE_URL, "/me"),
+    { method: "GET" },
+    { includeIdToken: true },
+  )
 
-  if (!accessToken || !idToken) {
-    return null
-  }
-
-  const response = await fetch(getEndpointUrl(PROFILE_SERVICE_URL, "/me"), {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "X-Id-Token": idToken,
-    },
-    cache: "no-store",
-  })
-
-  if (!response.ok) {
+  if (!response || !response.ok) {
     return null
   }
 

--- a/lib/serviceability-server.ts
+++ b/lib/serviceability-server.ts
@@ -1,39 +1,44 @@
-import "server-only"
-
 import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { authenticatedServerFetch } from "@/lib/server-auth"
 
 export type ServiceabilityResponse = {
   serviceable: boolean
-  matchedZoneId?: string | null
-  matchedZoneName?: string | null
-  city?: string | null
-  station?: string | null
-  reasonCode?: string
   message?: string
+  station?: string
+  city?: string
 }
 
 export async function checkAuthenticatedServiceability(
   latitude: number,
   longitude: number,
-  token: string,
 ): Promise<ServiceabilityResponse> {
-  const response = await fetch(getEndpointUrl(ORDER_SERVICE_URL, "/service-zones/check-serviceability"), {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
+  const response = await authenticatedServerFetch(
+    getEndpointUrl(ORDER_SERVICE_URL, "/service-zones/check-serviceability"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ latitude, longitude }),
     },
-    body: JSON.stringify({ latitude, longitude }),
-    cache: "no-store",
-  })
+  )
+
+  if (!response) {
+    return {
+      serviceable: false,
+      message: "Unauthorized",
+    }
+  }
 
   const data = (await response.json().catch(() => null)) as ServiceabilityResponse | { message?: string } | null
 
   if (!response.ok) {
-    throw new Error((data as { message?: string } | null)?.message || "Failed to check address serviceability")
+    return {
+      serviceable: false,
+      message: (data as { message?: string } | null)?.message || "Unable to verify serviceability.",
+    }
   }
 
   return (data || { serviceable: false }) as ServiceabilityResponse
 }
-

--- a/lib/serviceability-service.ts
+++ b/lib/serviceability-service.ts
@@ -1,7 +1,8 @@
+import { apiFetch } from "@/lib/client-api"
 import type { ServiceabilityResponse } from "@/lib/serviceability-server"
 
 export async function checkAddressServiceability(latitude: number, longitude: number): Promise<ServiceabilityResponse> {
-  const response = await fetch("/api/serviceability", {
+  const response = await apiFetch("/api/serviceability", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/lib/token-refresh.ts
+++ b/lib/token-refresh.ts
@@ -1,52 +1,26 @@
+import { cleanupLegacyTokenStorage } from "@/lib/client-api"
+
 /**
- * Utility function to refresh the access token using the refresh token
+ * Legacy-compatible refresh helper.
+ * Tokens are now stored in httpOnly cookies only.
  */
 export async function refreshAccessToken() {
   try {
-    const refreshToken = localStorage.getItem("maplexpress_refresh_token")
-
-    if (!refreshToken) {
-      throw new Error("No refresh token available")
-    }
-
-    // Call your refresh token endpoint
     const response = await fetch("/api/auth/refresh", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ refreshToken }),
+      credentials: "include",
+      cache: "no-store",
     })
-
-    const data = await response.json()
 
     if (!response.ok) {
       throw new Error("Failed to refresh token")
     }
 
-    // Update the stored tokens
-    localStorage.setItem("maplexpress_access_token", data.accessToken)
-
-    // If a new refresh token is provided, update it too
-    if (data.refreshToken) {
-      localStorage.setItem("maplexpress_refresh_token", data.refreshToken)
-    }
-
-    // Update user data if provided
-    if (data.tokenExpiration) {
-      const userData = JSON.parse(localStorage.getItem("maplexpress_user_data") || "{}")
-      userData.tokenExpiration = data.tokenExpiration
-      localStorage.setItem("maplexpress_user_data", JSON.stringify(userData))
-    }
-
-    return data.accessToken
+    cleanupLegacyTokenStorage()
+    return true
   } catch (error) {
-    // If refresh fails, log out the user
-    localStorage.removeItem("maplexpress_access_token")
-    localStorage.removeItem("maplexpress_refresh_token")
-    localStorage.removeItem("maplexpress_user_data")
-    window.location.href = "/" // Redirect to home page
-    throw error
+    cleanupLegacyTokenStorage()
+    console.error("Token refresh failed:", error)
+    return false
   }
 }
-


### PR DESCRIPTION
### Motivation
- Centralize authentication/token handling on the server to reduce duplication and ensure refresh logic is consistent across routes. 
- Provide an authenticated proxy for server routes to automatically retry with refreshed tokens and to set/clear httpOnly cookies. 
- Move client-side requests to a single `apiFetch` helper that supports automatic refresh to remove legacy localStorage/sessionStorage token usage. 

### Description
- Added `lib/server-auth.ts` to centralize cookie-based token extraction, refresh (`maybeRefreshTokens`), and cookie helpers `applyAuthCookies`/`clearAuthCookies`, and added `getServerAuthHeaders` for server use. 
- Implemented `lib/authenticated-proxy.ts` to proxy backend requests with automatic 401->refresh->retry behavior and to apply/clear auth cookies on responses. 
- Implemented client helpers in `lib/client-api.ts` (`apiFetch`, `initSessionRefresh`, `cleanupLegacyTokenStorage`) and wired them into client modules (`lib/me-service.ts`, `lib/onboarding-service.ts`, `lib/order-service.ts`, `lib/payment-service.ts`, `lib/serviceability-service.ts`, `lib/address-service.ts`, `lib/moneris/moneris-service.ts`, etc.). 
- Reworked API routes to use the proxy and server auth utilities (e.g. `app/api/*` routes now call `proxyWithAuthRetry`, `applyAuthCookies`, `clearAuthCookies`) and removed duplicated cookie/header handling across many files. 
- Updated admin/server-only services to use `getServerAuthHeaders` instead of reading cookies directly, and simplified token-refresh helper `lib/token-refresh.ts` to be legacy-compatible while migrating to cookie-first approach. 
- Updated client `AuthProvider` to initialize session refresh and cleanup legacy storage, and replaced direct `fetch` logout and profile calls with `apiFetch`. 

### Testing
- Ran TypeScript build/type-check (`tsc`) against the codebase with no type errors. 
- Ran the existing automated unit/integration test suite and linters; the test suite completed successfully. 
- Performed automated smoke checks against key auth flows (`POST /api/auth/login`, `POST /api/auth/refresh`, `POST /api/auth/logout`) and core proxied endpoints (`/api/orders`, `/api/profile/me`, `/api/payments/checkout`) which returned expected statuses in local environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda73eb3ec8329bf7b5ab516c6f158)