### PR TITLE
Refine Shipment Details panel fields, timestamps, and item pricing

### DIFF
--- a/components/dashboard/shipments.tsx
+++ b/components/dashboard/shipments.tsx
@@ -1,102 +1,172 @@
-"use client"
+"use client";
 
-import { useEffect, useMemo, useState } from "react"
-import { getClientOrders, type ClientOrder, type ClientOrdersFilters } from "@/lib/order-service"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Skeleton } from "@/components/ui/skeleton"
-import { CalendarClock, Package, Route, Truck, AlertCircle } from "lucide-react"
+import { useEffect, useMemo, useState } from "react";
+import {
+  getClientOrders,
+  type ClientOrder,
+  type ClientOrdersFilters,
+} from "@/lib/order-service";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  CalendarClock,
+  Package,
+  Route,
+  Truck,
+  AlertCircle,
+} from "lucide-react";
+import { format } from "date-fns";
 
-type SortOption = "newest" | "oldest" | "updated"
+type SortOption = "newest" | "oldest" | "updated";
 
-const PAGE_SIZE = 10
+const PAGE_SIZE = 10;
 
-function getSortParams(sort: SortOption): Pick<ClientOrdersFilters, "sortBy" | "sortDir"> {
+function getSortParams(
+  sort: SortOption,
+): Pick<ClientOrdersFilters, "sortBy" | "sortDir"> {
   switch (sort) {
     case "oldest":
-      return { sortBy: "createdAt", sortDir: "asc" }
+      return { sortBy: "createdAt", sortDir: "asc" };
     case "updated":
-      return { sortBy: "updatedAt", sortDir: "desc" }
+      return { sortBy: "updatedAt", sortDir: "desc" };
     case "newest":
     default:
-      return { sortBy: "createdAt", sortDir: "desc" }
+      return { sortBy: "createdAt", sortDir: "desc" };
   }
 }
 
 function statusBadge(status?: string | null) {
-  const value = (status || "").toLowerCase()
-  const success = new Set(["confirmed", "delivered", "partial_complete"])
-  const progress = new Set(["label_created", "scheduled", "assigned", "picked_up", "in_transit", "in_progress"])
-  const warning = new Set(["payment_pending", "end_of_day"])
-  const danger = new Set(["payment_failed", "pickup_failed", "drop_off_failed", "failed", "cancelled"])
-  const neutral = new Set(["draft", "returned"])
+  const value = (status || "").toLowerCase();
+  const success = new Set(["confirmed", "delivered", "partial_complete"]);
+  const progress = new Set([
+    "label_created",
+    "scheduled",
+    "assigned",
+    "picked_up",
+    "in_transit",
+    "in_progress",
+  ]);
+  const warning = new Set(["payment_pending", "end_of_day"]);
+  const danger = new Set([
+    "payment_failed",
+    "pickup_failed",
+    "drop_off_failed",
+    "failed",
+    "cancelled",
+  ]);
+  const neutral = new Set(["draft", "returned"]);
 
-  let tone = "bg-slate-100 text-slate-700 border-slate-200"
-  if (success.has(value)) tone = "bg-emerald-100 text-emerald-800 border-emerald-200"
-  else if (progress.has(value)) tone = "bg-sky-100 text-sky-800 border-sky-200"
-  else if (warning.has(value)) tone = "bg-amber-100 text-amber-900 border-amber-200"
-  else if (danger.has(value)) tone = "bg-rose-100 text-rose-800 border-rose-200"
-  else if (neutral.has(value)) tone = "bg-zinc-100 text-zinc-700 border-zinc-200"
+  let tone = "bg-slate-100 text-slate-700 border-slate-200";
+  if (success.has(value))
+    tone = "bg-emerald-100 text-emerald-800 border-emerald-200";
+  else if (progress.has(value)) tone = "bg-sky-100 text-sky-800 border-sky-200";
+  else if (warning.has(value))
+    tone = "bg-amber-100 text-amber-900 border-amber-200";
+  else if (danger.has(value))
+    tone = "bg-rose-100 text-rose-800 border-rose-200";
+  else if (neutral.has(value))
+    tone = "bg-zinc-100 text-zinc-700 border-zinc-200";
 
   const label = status
     ? status
         .split("_")
         .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
         .join(" ")
-    : "Unknown"
+    : "Unknown";
 
   return (
-    <Badge variant="outline" className={`h-6 rounded-md px-2 text-[11px] border ${tone}`}>
+    <Badge
+      variant="outline"
+      className={`h-6 rounded-md px-2 text-[11px] border ${tone}`}
+    >
       {label}
     </Badge>
-  )
+  );
 }
 
 function summarizeRoute(order: ClientOrder) {
-  const item = order.orderItems?.[0]
-  const pickup = item?.pickup?.address?.city
-  const dropoff = item?.dropoff?.address?.city
-  return pickup && dropoff ? `${pickup} → ${dropoff}` : "Route unavailable"
+  const item = order.orderItems?.[0];
+  const pickup = item?.pickup?.address?.city;
+  const dropoff = item?.dropoff?.address?.city;
+  return pickup && dropoff ? `${pickup} → ${dropoff}` : "Route unavailable";
 }
 
 function summarizeTracking(order: ClientOrder) {
-  const ids = order.orderItems?.map((i) => i.trackingId).filter(Boolean) as string[]
-  if (!ids?.length) return "No tracking"
-  if (ids.length === 1) return ids[0]
-  return `${ids[0]} +${ids.length - 1}`
+  const ids = order.orderItems
+    ?.map((i) => i.trackingId)
+    .filter(Boolean) as string[];
+  if (!ids?.length) return "No tracking";
+  if (ids.length === 1) return ids[0];
+  return `${ids[0]} +${ids.length - 1}`;
 }
 
 function money(value?: number | null) {
-  if (typeof value !== "number") return "N/A"
-  return new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD" }).format(value)
+  if (typeof value !== "number") return "N/A";
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+  }).format(value);
 }
 
-function itemBucket(status?: string | null): "delivered" | "in_progress" | "failed" {
-  const v = (status || "").toLowerCase()
-  if (["delivered", "partial_complete"].includes(v)) return "delivered"
-  if (["draft", "payment_pending", "payment_failed", "pickup_failed", "returned", "failed", "cancelled"].includes(v)) return "failed"
-  return "in_progress"
+function formatOrderDate(value?: string | null) {
+  if (!value) return "N/A";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "N/A";
+  return format(date, "MMM d, yyyy • h:mm a");
+}
+
+function itemBucket(
+  status?: string | null,
+): "delivered" | "in_progress" | "failed" {
+  const v = (status || "").toLowerCase();
+  if (["delivered", "partial_complete"].includes(v)) return "delivered";
+  if (
+    [
+      "draft",
+      "payment_pending",
+      "payment_failed",
+      "pickup_failed",
+      "returned",
+      "failed",
+      "cancelled",
+    ].includes(v)
+  )
+    return "failed";
+  return "in_progress";
 }
 
 export function Shipments() {
-  const [sortOption, setSortOption] = useState<SortOption>("newest")
-  const [page, setPage] = useState(0)
+  const [sortOption, setSortOption] = useState<SortOption>("newest");
+  const [page, setPage] = useState(0);
 
-  const [ordersPage, setOrdersPage] = useState<ClientOrder[]>([])
-  const [totalElements, setTotalElements] = useState(0)
-  const [totalPages, setTotalPages] = useState(0)
-  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null)
+  const [ordersPage, setOrdersPage] = useState<ClientOrder[]>([]);
+  const [totalElements, setTotalElements] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
 
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const sortParams = useMemo(() => getSortParams(sortOption), [sortOption])
+  const sortParams = useMemo(() => getSortParams(sortOption), [sortOption]);
 
   const loadOrders = async () => {
-    setIsLoading(true)
-    setError(null)
+    setIsLoading(true);
+    setError(null);
 
     try {
       const response = await getClientOrders({
@@ -104,60 +174,65 @@ export function Shipments() {
         size: PAGE_SIZE,
         sortBy: sortParams.sortBy,
         sortDir: sortParams.sortDir,
-      })
+      });
 
-      setOrdersPage(response.orders || [])
-      setTotalElements(response.pagination?.totalElements || 0)
-      setTotalPages(Math.max(1, response.pagination?.totalPages || 1))
+      setOrdersPage(response.orders || []);
+      setTotalElements(response.pagination?.totalElements || 0);
+      setTotalPages(Math.max(1, response.pagination?.totalPages || 1));
     } catch (err) {
-      console.error("Failed to fetch orders", err)
-      setError("Failed to load shipments. Please try again.")
-      setOrdersPage([])
-      setTotalElements(0)
-      setTotalPages(0)
+      console.error("Failed to fetch orders", err);
+      setError("Failed to load shipments. Please try again.");
+      setOrdersPage([]);
+      setTotalElements(0);
+      setTotalPages(0);
     } finally {
-      setIsLoading(false)
+      setIsLoading(false);
     }
-  }
+  };
 
   useEffect(() => {
-    loadOrders()
-  }, [page, sortParams])
+    loadOrders();
+  }, [page, sortParams]);
 
   useEffect(() => {
     if (!ordersPage.length) {
-      setSelectedOrderId(null)
-      return
+      setSelectedOrderId(null);
+      return;
     }
 
-    const exists = selectedOrderId && ordersPage.some((o) => o.shippingOrderId === selectedOrderId)
+    const exists =
+      selectedOrderId &&
+      ordersPage.some((o) => o.shippingOrderId === selectedOrderId);
     if (!exists) {
-      setSelectedOrderId(ordersPage[0].shippingOrderId)
+      setSelectedOrderId(ordersPage[0].shippingOrderId);
     }
-  }, [ordersPage, selectedOrderId, page])
+  }, [ordersPage, selectedOrderId, page]);
 
   const selectedOrder = useMemo(
     () => ordersPage.find((o) => o.shippingOrderId === selectedOrderId) || null,
     [ordersPage, selectedOrderId],
-  )
+  );
 
   const itemProgress = useMemo(() => {
-    if (!selectedOrder?.orderItems?.length) return { delivered: 0, in_progress: 0, failed: 0 }
+    if (!selectedOrder?.orderItems?.length)
+      return { delivered: 0, in_progress: 0, failed: 0 };
 
     return selectedOrder.orderItems.reduce(
-      (acc, item: any) => {
-        const bucket = itemBucket(item.itemStatus)
-        acc[bucket] += 1
-        return acc
+      (acc, item) => {
+        const bucket = itemBucket(item.itemStatus);
+        acc[bucket] += 1;
+        return acc;
       },
       { delivered: 0, in_progress: 0, failed: 0 },
-    )
-  }, [selectedOrder])
+    );
+  }, [selectedOrder]);
 
   return (
     <div className="space-y-3">
       <div className="rounded-lg border bg-background px-3 py-2">
-        <h1 className="text-xl font-semibold tracking-tight">Shipments Workspace</h1>
+        <h1 className="text-xl font-semibold tracking-tight">
+          Shipments Workspace
+        </h1>
       </div>
 
       {error && (
@@ -175,8 +250,8 @@ export function Shipments() {
               <Select
                 value={sortOption}
                 onValueChange={(value: SortOption) => {
-                  setSortOption(value)
-                  setPage(0)
+                  setSortOption(value);
+                  setPage(0);
                 }}
               >
                 <SelectTrigger className="h-8 text-xs w-[150px]">
@@ -189,7 +264,9 @@ export function Shipments() {
               </Select>
             </div>
 
-            <CardDescription className="text-xs">{totalElements} orders</CardDescription>
+            <CardDescription className="text-xs">
+              {totalElements} orders
+            </CardDescription>
           </CardHeader>
 
           <CardContent className="px-0 pb-2 flex-1 flex flex-col min-h-0">
@@ -209,7 +286,7 @@ export function Shipments() {
             ) : (
               <div className="divide-y border-y flex-1">
                 {ordersPage.map((order) => {
-                  const selected = selectedOrderId === order.shippingOrderId
+                  const selected = selectedOrderId === order.shippingOrderId;
                   return (
                     <button
                       key={order.shippingOrderId}
@@ -217,23 +294,39 @@ export function Shipments() {
                       onClick={() => setSelectedOrderId(order.shippingOrderId)}
                     >
                       <div className="flex items-center justify-between gap-2">
-                        <p className="text-sm font-semibold truncate">{order.shippingOrderId}</p>
-                        <p className="text-xs font-semibold">{money(order.aggregatedPricing?.totalAmount)}</p>
+                        <p className="text-sm font-semibold truncate">
+                          {order.shippingOrderId}
+                        </p>
+                        <p className="text-xs font-semibold">
+                          {money(order.aggregatedPricing?.totalAmount)}
+                        </p>
                       </div>
-                      <div className="mt-1 flex items-center gap-2">{statusBadge(order.orderStatus)}</div>
+                      <div className="mt-1 flex items-center gap-2">
+                        {statusBadge(order.orderStatus)}
+                      </div>
                       <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
-                        <span className="inline-flex items-center gap-1"><Route className="h-3 w-3" /> {summarizeRoute(order)}</span>
-                        <span className="inline-flex items-center gap-1"><CalendarClock className="h-3 w-3" /> {new Date(order.createdAt).toLocaleDateString()}</span>
-                        <span className="inline-flex items-center gap-1"><Package className="h-3 w-3" /> {order.orderItems?.length || 0} items</span>
+                        <span className="inline-flex items-center gap-1">
+                          <Route className="h-3 w-3" /> {summarizeRoute(order)}
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <CalendarClock className="h-3 w-3" />{" "}
+                          {new Date(order.createdAt).toLocaleDateString()}
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <Package className="h-3 w-3" />{" "}
+                          {order.orderItems?.length || 0} items
+                        </span>
                       </div>
                     </button>
-                  )
+                  );
                 })}
               </div>
             )}
 
             <div className="flex items-center justify-between px-3 pt-2 mt-auto border-t">
-              <p className="text-[11px] text-muted-foreground">Page {page + 1} / {Math.max(totalPages, 1)}</p>
+              <p className="text-[11px] text-muted-foreground">
+                Page {page + 1} / {Math.max(totalPages, 1)}
+              </p>
               <div className="flex gap-1">
                 <button
                   className="text-xs border rounded px-2 py-1 disabled:opacity-50"
@@ -265,20 +358,31 @@ export function Shipments() {
                 <div className="border rounded-md p-3 space-y-2">
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <h2 className="text-lg font-semibold">{selectedOrder.shippingOrderId}</h2>
+                      <h2 className="text-lg font-semibold">
+                        {selectedOrder.shippingOrderId}
+                      </h2>
                       {statusBadge(selectedOrder.orderStatus)}
                     </div>
-                    <p className="text-lg font-semibold">{money(selectedOrder.aggregatedPricing?.totalAmount)}</p>
+                    <p className="text-lg font-semibold">
+                      {money(selectedOrder.aggregatedPricing?.totalAmount)}
+                    </p>
                   </div>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-xs text-muted-foreground">
-                    <div>Created: {selectedOrder.createdAt ? new Date(selectedOrder.createdAt).toLocaleString() : "N/A"}</div>
-                    <div>Payment: {(selectedOrder as any).paymentStatus || "N/A"}</div>
-                    <div>Updated: {(selectedOrder as any).updatedAt ? new Date((selectedOrder as any).updatedAt).toLocaleString() : "N/A"}</div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-muted-foreground">
+                    <div>
+                      Created: {formatOrderDate(selectedOrder.createdAt)}
+                    </div>
+                    <div>Payment: {selectedOrder.paymentStatus || "N/A"}</div>
                   </div>
                   <div className="flex flex-wrap items-center gap-2 text-xs">
-                    <Badge variant="outline" className="h-6">Delivered: {itemProgress.delivered}</Badge>
-                    <Badge variant="outline" className="h-6">In Progress: {itemProgress.in_progress}</Badge>
-                    <Badge variant="outline" className="h-6">Failed: {itemProgress.failed}</Badge>
+                    <Badge variant="outline" className="h-6">
+                      Delivered: {itemProgress.delivered}
+                    </Badge>
+                    <Badge variant="outline" className="h-6">
+                      In Progress: {itemProgress.in_progress}
+                    </Badge>
+                    <Badge variant="outline" className="h-6">
+                      Failed: {itemProgress.failed}
+                    </Badge>
                   </div>
                 </div>
 
@@ -286,34 +390,62 @@ export function Shipments() {
                   <h3 className="text-sm font-semibold">Order Items</h3>
                   {selectedOrder.orderItems?.length ? (
                     <div className="divide-y border rounded-md">
-                      {selectedOrder.orderItems.map((item: any, idx: number) => (
-                        <div key={item.trackingId || idx} className="p-2.5 space-y-1.5">
+                      {selectedOrder.orderItems.map((item, idx: number) => (
+                        <div
+                          key={item.trackingId || idx}
+                          className="p-2.5 space-y-1.5"
+                        >
                           <div className="flex items-center justify-between gap-2">
                             <div className="flex items-center gap-2 flex-wrap">
-                              <p className="text-sm font-medium">Item {idx + 1}</p>
+                              <p className="text-sm font-medium">
+                                Item {idx + 1}
+                              </p>
                               {statusBadge(item.itemStatus)}
                             </div>
-                            <p className="text-xs text-muted-foreground">Tracking: {item.trackingId || "N/A"}</p>
+                            <div className="text-right">
+                              <p className="text-sm font-semibold">
+                                {money(item.pricing?.totalAmount)}
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                Tracking: {item.trackingId || "N/A"}
+                              </p>
+                            </div>
                           </div>
                           <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-muted-foreground">
                             <div>
-                              <p className="font-medium text-foreground">Pickup</p>
-                              <p>{item.pickup?.address?.city || "N/A"} • {item.pickup?.address?.streetAddress || "Address unavailable"}</p>
+                              <p className="font-medium text-foreground">
+                                Pickup
+                              </p>
+                              <p>
+                                {item.pickup?.address?.city || "N/A"} •{" "}
+                                {item.pickup?.address?.streetAddress ||
+                                  "Address unavailable"}
+                              </p>
                             </div>
                             <div>
-                              <p className="font-medium text-foreground">Dropoff</p>
-                              <p>{item.dropoff?.address?.city || "N/A"} • {item.dropoff?.address?.streetAddress || "Address unavailable"}</p>
+                              <p className="font-medium text-foreground">
+                                Dropoff
+                              </p>
+                              <p>
+                                {item.dropoff?.address?.city || "N/A"} •{" "}
+                                {item.dropoff?.address?.streetAddress ||
+                                  "Address unavailable"}
+                              </p>
                             </div>
-                            <div>Package: {item.packageDetails?.type || "N/A"} • {item.packageDetails?.weight ?? "N/A"} kg</div>
-                            <div>ETA: {item.estimatedDeliveryTime ? new Date(item.estimatedDeliveryTime).toLocaleString() : "N/A"}</div>
-                            <div>Fragile: {item.isFragile ? "Yes" : "No"}</div>
-                            <div>Incidents: {item.specialIncidents?.length || 0}</div>
+                            <div>
+                              Weight:{" "}
+                              {typeof item.packageDetails?.weight === "number"
+                                ? `${item.packageDetails.weight} kg`
+                                : "N/A"}
+                            </div>
                           </div>
                         </div>
                       ))}
                     </div>
                   ) : (
-                    <div className="text-xs text-muted-foreground border rounded-md p-3">No order items available.</div>
+                    <div className="text-xs text-muted-foreground border rounded-md p-3">
+                      No order items available.
+                    </div>
                   )}
                 </div>
               </>
@@ -322,5 +454,5 @@ export function Shipments() {
         </Card>
       </div>
     </div>
-  )
+  );
 }

--- a/components/dashboard/shipments.tsx
+++ b/components/dashboard/shipments.tsx
@@ -395,21 +395,21 @@ export function Shipments() {
                           key={item.trackingId || idx}
                           className="p-2.5 space-y-1.5"
                         >
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="flex items-center gap-2 flex-wrap">
-                              <p className="text-sm font-medium">
-                                Item {idx + 1}
-                              </p>
-                              {statusBadge(item.itemStatus)}
-                            </div>
-                            <div className="text-right">
-                              <p className="text-sm font-semibold">
-                                {money(item.pricing?.totalAmount)}
-                              </p>
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="space-y-1">
+                              <div className="flex items-center gap-2 flex-wrap">
+                                <p className="text-sm font-medium">
+                                  Item {idx + 1}
+                                </p>
+                                {statusBadge(item.itemStatus)}
+                              </div>
                               <p className="text-xs text-muted-foreground">
                                 Tracking: {item.trackingId || "N/A"}
                               </p>
                             </div>
+                            <p className="text-sm font-semibold whitespace-nowrap">
+                              {money(item.pricing?.totalAmount)}
+                            </p>
                           </div>
                           <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-muted-foreground">
                             <div>

--- a/lib/order-service.ts
+++ b/lib/order-service.ts
@@ -1,371 +1,405 @@
-import type { ShippingOrder, Address } from "@/components/ship-now/ship-now-form"
+import type {
+  ShippingOrder,
+  Address,
+} from "@/components/ship-now/ship-now-form";
 
-import { apiFetch } from "@/lib/client-api"
+import { apiFetch } from "@/lib/client-api";
 
 // Define the API response types based on the actual response format
 export interface OrderResponse {
-    shippingOrderId: string
-    customerId: string
-    customerContact: {
-        name: string
-        phone: string
-        email: string
-    }
-    priorityDelivery: boolean
-    isFragile?: boolean
-    orderStatus: string
-    paymentStatus: string
-    createdAt: string
-    updatedAt: string
-    aggregatedPricing: {
-        basePrice: number
-        distanceCharge: number
-        weightCharge: number
-        dimensionalWeightCharge: number
-        prioritySurcharge: number
-        discount: number
-        taxes: {
-            amount: number
-            taxType: string
-        }[]
-        totalAmount: number
-        pricingId: string | null
-    }
-    orderItems: OrderItemResponse[]
+  shippingOrderId: string;
+  customerId: string;
+  customerContact: {
+    name: string;
+    phone: string;
+    email: string;
+  };
+  priorityDelivery: boolean;
+  isFragile?: boolean;
+  orderStatus: string;
+  paymentStatus: string;
+  createdAt: string;
+  updatedAt: string;
+  aggregatedPricing: {
+    basePrice: number;
+    distanceCharge: number;
+    weightCharge: number;
+    dimensionalWeightCharge: number;
+    prioritySurcharge: number;
+    discount: number;
+    taxes: {
+      amount: number;
+      taxType: string;
+    }[];
+    totalAmount: number;
+    pricingId: string | null;
+  };
+  orderItems: OrderItemResponse[];
 }
 
 export interface OrderItemResponse {
-    orderItemId?: string
-    trackingId?: string
-    pickup: {
-        address: AddressResponse
-        coordinates?: {
-            latitude: number
-            longitude: number
-        }
-        time: string
-        notes: string
-        images: any[]
-    }
-    dropoff: {
-        address: AddressResponse
-        coordinates?: {
-            latitude: number
-            longitude: number
-        }
-        time: string
-        notes: string
-        images: any[]
-    }
-    distanceToDelivery: number
-    packageDetails: {
-        weight: number
-        dimensions: {
-            length: number
-            width: number
-            height: number
-        }
-        type: string | null
-        value: number | null
-        images: {
-            imageUrl: string
-            timestamp: string
-        }[]
-    }
-    isFragile?: boolean
-    pricing: {
-        basePrice: number
-        distanceCharge: number
-        weightCharge: number
-        prioritySurcharge: number
-        taxes: {
-            amount: number
-            taxType: string
-        }[]
-        totalAmount: number
-        pricingId: string
-    }
-    itemStatus: string
-    trackingNumber: string | null
-    estimatedDeliveryTime: string | null
-    specialIncidents: any[]
+  orderItemId?: string;
+  trackingId?: string;
+  pickup: {
+    address: AddressResponse;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    time: string;
+    notes: string;
+    images: any[];
+  };
+  dropoff: {
+    address: AddressResponse;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    time: string;
+    notes: string;
+    images: any[];
+  };
+  distanceToDelivery: number;
+  packageDetails: {
+    weight: number;
+    dimensions: {
+      length: number;
+      width: number;
+      height: number;
+    };
+    type: string | null;
+    value: number | null;
+    images: {
+      imageUrl: string;
+      timestamp: string;
+    }[];
+  };
+  isFragile?: boolean;
+  pricing: {
+    basePrice: number;
+    distanceCharge: number;
+    weightCharge: number;
+    prioritySurcharge: number;
+    taxes: {
+      amount: number;
+      taxType: string;
+    }[];
+    totalAmount: number;
+    pricingId: string;
+  };
+  itemStatus: string;
+  trackingNumber: string | null;
+  estimatedDeliveryTime: string | null;
+  specialIncidents: any[];
 }
 
 export interface ClientOrder {
-    shippingOrderId: string
-    orderStatus: string
-    paymentStatus: string
-    priorityDelivery: boolean
-    createdAt: string
-    aggregatedPricing?: {
-        totalAmount?: number
-    }
-    orderItems: Array<{
-        trackingId?: string | null
-        pickup?: {
-            address?: {
-                city?: string
-            }
-        }
-        dropoff?: {
-            address?: {
-                city?: string
-            }
-        }
-    }>
+  shippingOrderId: string;
+  orderStatus: string;
+  paymentStatus: string;
+  priorityDelivery: boolean;
+  createdAt: string;
+  updatedAt?: string;
+  aggregatedPricing?: {
+    totalAmount?: number;
+  };
+  orderItems: Array<{
+    trackingId?: string | null;
+    itemStatus?: string | null;
+    pickup?: {
+      address?: {
+        city?: string;
+        streetAddress?: string;
+      };
+    };
+    dropoff?: {
+      address?: {
+        city?: string;
+        streetAddress?: string;
+      };
+    };
+    packageDetails?: {
+      weight?: number | null;
+    };
+    pricing?: {
+      totalAmount?: number | null;
+    };
+  }>;
 }
 
 export interface ClientOrdersFilters {
-    orderStatus?: string
-    paymentStatus?: string
-    createdFrom?: string
-    createdTo?: string
-    page?: number
-    size?: number
-    sortBy?: string
-    sortDir?: "asc" | "desc"
+  orderStatus?: string;
+  paymentStatus?: string;
+  createdFrom?: string;
+  createdTo?: string;
+  page?: number;
+  size?: number;
+  sortBy?: string;
+  sortDir?: "asc" | "desc";
 }
 
 interface ClientOrdersResponse {
-    orders: ClientOrder[]
-    pagination: {
-        page: number
-        size: number
-        totalElements: number
-        totalPages: number
-        sortBy: string
-        sortDir: "asc" | "desc"
-    }
+  orders: ClientOrder[];
+  pagination: {
+    page: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+    sortBy: string;
+    sortDir: "asc" | "desc";
+  };
 }
 
 interface OrderRequestItem {
-    pickup: {
-        address: ReturnType<typeof formatAddress>
-        time: string
-        notes: string
-    }
-    dropoff: {
-        address: ReturnType<typeof formatAddress>
-        time: string
-        notes: string
-    }
-    packageDetails: {
-        weight: number
-        dimensions: {
-            length: number
-            width: number
-            height: number
-        }
-    }
-    isFragile?: boolean
+  pickup: {
+    address: ReturnType<typeof formatAddress>;
+    time: string;
+    notes: string;
+  };
+  dropoff: {
+    address: ReturnType<typeof formatAddress>;
+    time: string;
+    notes: string;
+  };
+  packageDetails: {
+    weight: number;
+    dimensions: {
+      length: number;
+      width: number;
+      height: number;
+    };
+  };
+  isFragile?: boolean;
 }
 
 interface OrderRequest {
-    customerId: string
-    priorityDelivery: boolean
-    isFragile?: boolean
-    orderItems: OrderRequestItem[]
-    shippingOrderId?: string
+  customerId: string;
+  priorityDelivery: boolean;
+  isFragile?: boolean;
+  orderItems: OrderRequestItem[];
+  shippingOrderId?: string;
 }
 
 interface AddressResponse {
-    fullName: string
-    company: string
-    streetAddress: string
-    addressLine2: string
-    city: string
-    province: string
-    postalCode: string
-    country: string
-    phoneNumber: string
-    deliveryInstructions: string
+  fullName: string;
+  company: string;
+  streetAddress: string;
+  addressLine2: string;
+  city: string;
+  province: string;
+  postalCode: string;
+  country: string;
+  phoneNumber: string;
+  deliveryInstructions: string;
 }
 
 // Function to create or update a draft order
 export async function createDraftOrder(
-    order: ShippingOrder,
-    userId: string,
-    priorityDelivery = false,
-    existingOrderId?: string,
+  order: ShippingOrder,
+  userId: string,
+  priorityDelivery = false,
+  existingOrderId?: string,
 ): Promise<OrderResponse> {
-    try {
-        if (!userId) {
-            throw new Error("User ID not found")
-        }
-
-        // Format the request body according to the API requirements
-        const requestBody = formatOrderRequest(order, userId, priorityDelivery, existingOrderId)
-
-        const response = existingOrderId
-            ? await updateOrder(requestBody)
-            : await createOrder(requestBody)
-
-        const data = await response.json().catch(() => null)
-
-        if (!response.ok) {
-            const backendMessage = data && typeof data === "object" && "message" in data ? (data as { message?: string }).message : null
-            throw new Error(
-                backendMessage || `Failed to ${existingOrderId ? "update" : "create"} order: ${response.statusText}`,
-            )
-        }
-
-        // Return the shippingOrder object from the response
-        return data.shippingOrder
-    } catch (error) {
-        console.error(`Error ${existingOrderId ? "updating" : "creating"} draft order:`, error)
-        throw error
+  try {
+    if (!userId) {
+      throw new Error("User ID not found");
     }
+
+    // Format the request body according to the API requirements
+    const requestBody = formatOrderRequest(
+      order,
+      userId,
+      priorityDelivery,
+      existingOrderId,
+    );
+
+    const response = existingOrderId
+      ? await updateOrder(requestBody)
+      : await createOrder(requestBody);
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      const backendMessage =
+        data && typeof data === "object" && "message" in data
+          ? (data as { message?: string }).message
+          : null;
+      throw new Error(
+        backendMessage ||
+          `Failed to ${existingOrderId ? "update" : "create"} order: ${response.statusText}`,
+      );
+    }
+
+    // Return the shippingOrder object from the response
+    return data.shippingOrder;
+  } catch (error) {
+    console.error(
+      `Error ${existingOrderId ? "updating" : "creating"} draft order:`,
+      error,
+    );
+    throw error;
+  }
 }
 
 // Helper function to format the order request
-function formatOrderRequest(order: ShippingOrder, userId: string, priorityDelivery: boolean, existingOrderId?: string): OrderRequest {
-    // Format the order items
-    const orderItems = order.packages.map((pkg) => {
-        return {
-            pickup: {
-                address: formatAddress(order.pickupAddress),
-                time: new Date().toISOString(), // Default to current time
-                notes: order.pickupAddress?.deliveryInstructions || "",
-            },
-            dropoff: {
-                address: formatAddress(pkg.dropoffAddress),
-                time: new Date(new Date().getTime() + 4 * 60 * 60 * 1000).toISOString(), // Default to 4 hours later
-                notes: pkg.dropoffAddress?.deliveryInstructions || "",
-            },
-            packageDetails: {
-                weight: pkg.weight,
-                dimensions: {
-                    length: pkg.length,
-                    width: pkg.width,
-                    height: pkg.height,
-                },
-            },
-            isFragile: pkg.fragile,
-        }
-    })
+function formatOrderRequest(
+  order: ShippingOrder,
+  userId: string,
+  priorityDelivery: boolean,
+  existingOrderId?: string,
+): OrderRequest {
+  // Format the order items
+  const orderItems = order.packages.map((pkg) => {
+    return {
+      pickup: {
+        address: formatAddress(order.pickupAddress),
+        time: new Date().toISOString(), // Default to current time
+        notes: order.pickupAddress?.deliveryInstructions || "",
+      },
+      dropoff: {
+        address: formatAddress(pkg.dropoffAddress),
+        time: new Date(new Date().getTime() + 4 * 60 * 60 * 1000).toISOString(), // Default to 4 hours later
+        notes: pkg.dropoffAddress?.deliveryInstructions || "",
+      },
+      packageDetails: {
+        weight: pkg.weight,
+        dimensions: {
+          length: pkg.length,
+          width: pkg.width,
+          height: pkg.height,
+        },
+      },
+      isFragile: pkg.fragile,
+    };
+  });
 
-    const requestBody: OrderRequest = {
-        customerId: userId,
-        priorityDelivery,
-        isFragile: orderItems.some((item) => item.isFragile),
-        orderItems,
-    }
+  const requestBody: OrderRequest = {
+    customerId: userId,
+    priorityDelivery,
+    isFragile: orderItems.some((item) => item.isFragile),
+    orderItems,
+  };
 
-    // If updating an existing order, include the shippingOrderId
-    if (existingOrderId) {
-        requestBody.shippingOrderId = existingOrderId
-    }
+  // If updating an existing order, include the shippingOrderId
+  if (existingOrderId) {
+    requestBody.shippingOrderId = existingOrderId;
+  }
 
-    return requestBody
+  return requestBody;
 }
 
 export async function createOrder(payload: OrderRequest) {
-    return apiFetch("/api/orders", {
-        method: "POST",
-        headers: {
-            accept: "application/json",
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-    })
+  return apiFetch("/api/orders", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
 }
 
 export async function updateOrder(payload: OrderRequest) {
-    return apiFetch("/api/orders", {
-        method: "PUT",
-        headers: {
-            accept: "application/json",
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-    })
+  return apiFetch("/api/orders", {
+    method: "PUT",
+    headers: {
+      accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
 }
 
 // Helper function to format address
 function formatAddress(address: Address | null) {
-    if (!address) return null
+  if (!address) return null;
 
-    return {
-        fullName: address.fullName,
-        company: address.company || "",
-        streetAddress: address.streetAddress,
-        addressLine2: address.addressLine2 || "",
-        city: address.city,
-        province: address.province,
-        postalCode: address.postalCode,
-        country: address.country,
-        phoneNumber: address.phoneNumber,
-        deliveryInstructions: address.deliveryInstructions || "",
-    }
+  return {
+    fullName: address.fullName,
+    company: address.company || "",
+    streetAddress: address.streetAddress,
+    addressLine2: address.addressLine2 || "",
+    city: address.city,
+    province: address.province,
+    postalCode: address.postalCode,
+    country: address.country,
+    phoneNumber: address.phoneNumber,
+    deliveryInstructions: address.deliveryInstructions || "",
+  };
 }
 
 // Fetch paid orders for a customer
-export async function getPaidOrdersByCustomer(customerId: string): Promise<OrderResponse[]> {
-    const url = `/api/orders?customerId=${encodeURIComponent(customerId)}&paymentStatus=paid`
+export async function getPaidOrdersByCustomer(
+  customerId: string,
+): Promise<OrderResponse[]> {
+  const url = `/api/orders?customerId=${encodeURIComponent(customerId)}&paymentStatus=paid`;
 
-    const response = await apiFetch(url, {
-        headers: {
-            accept: "application/json",
-            "Content-Type": "application/json",
-        },
-    })
+  const response = await apiFetch(url, {
+    headers: {
+      accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  });
 
-    if (!response.ok) {
-        throw new Error(`Failed to fetch orders: ${response.statusText}`)
-    }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch orders: ${response.statusText}`);
+  }
 
-    return response.json()
+  return response.json();
 }
 
-export async function getClientOrders(filters: ClientOrdersFilters): Promise<ClientOrdersResponse> {
-    const params = new URLSearchParams()
+export async function getClientOrders(
+  filters: ClientOrdersFilters,
+): Promise<ClientOrdersResponse> {
+  const params = new URLSearchParams();
 
-    if (filters.orderStatus) params.set("orderStatus", filters.orderStatus)
-    if (filters.paymentStatus) params.set("paymentStatus", filters.paymentStatus)
-    if (filters.createdFrom) params.set("createdFrom", filters.createdFrom)
-    if (filters.createdTo) params.set("createdTo", filters.createdTo)
+  if (filters.orderStatus) params.set("orderStatus", filters.orderStatus);
+  if (filters.paymentStatus) params.set("paymentStatus", filters.paymentStatus);
+  if (filters.createdFrom) params.set("createdFrom", filters.createdFrom);
+  if (filters.createdTo) params.set("createdTo", filters.createdTo);
 
-    params.set("page", String(filters.page ?? 0))
-    params.set("size", String(filters.size ?? 10))
-    params.set("sortBy", filters.sortBy ?? "createdAt")
-    params.set("sortDir", filters.sortDir ?? "desc")
+  params.set("page", String(filters.page ?? 0));
+  params.set("size", String(filters.size ?? 10));
+  params.set("sortBy", filters.sortBy ?? "createdAt");
+  params.set("sortDir", filters.sortDir ?? "desc");
 
-    const response = await apiFetch(`/api/orders?${params.toString()}`, {
-        headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-        },
-    })
+  const response = await apiFetch(`/api/orders?${params.toString()}`, {
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  });
 
-    if (!response.ok) {
-        throw new Error(`Failed to fetch orders: ${response.statusText}`)
-    }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch orders: ${response.statusText}`);
+  }
 
-    const data = await response.json()
+  const data = await response.json();
 
-    if (Array.isArray(data)) {
-        return {
-            orders: data,
-            pagination: {
-                page: filters.page ?? 0,
-                size: filters.size ?? 10,
-                totalElements: data.length,
-                totalPages: data.length ? 1 : 0,
-                sortBy: filters.sortBy ?? "createdAt",
-                sortDir: filters.sortDir ?? "desc",
-            },
-        }
-    }
-
+  if (Array.isArray(data)) {
     return {
-        orders: data?.orders ?? [],
-        pagination: {
-            page: data?.pagination?.page ?? 0,
-            size: data?.pagination?.size ?? filters.size ?? 10,
-            totalElements: data?.pagination?.totalElements ?? 0,
-            totalPages: data?.pagination?.totalPages ?? 0,
-            sortBy: data?.pagination?.sortBy ?? "createdAt",
-            sortDir: data?.pagination?.sortDir === "asc" ? "asc" : "desc",
-        },
-    }
+      orders: data,
+      pagination: {
+        page: filters.page ?? 0,
+        size: filters.size ?? 10,
+        totalElements: data.length,
+        totalPages: data.length ? 1 : 0,
+        sortBy: filters.sortBy ?? "createdAt",
+        sortDir: filters.sortDir ?? "desc",
+      },
+    };
+  }
+
+  return {
+    orders: data?.orders ?? [],
+    pagination: {
+      page: data?.pagination?.page ?? 0,
+      size: data?.pagination?.size ?? filters.size ?? 10,
+      totalElements: data?.pagination?.totalElements ?? 0,
+      totalPages: data?.pagination?.totalPages ?? 0,
+      sortBy: data?.pagination?.sortBy ?? "createdAt",
+      sortDir: data?.pagination?.sortDir === "asc" ? "asc" : "desc",
+    },
+  };
 }


### PR DESCRIPTION
### Motivation
- Simplify the Shipment Details UI to reduce noise and improve scanability by removing rarely-used fields and making important data (timestamps, prices, weight) clearer. 
- Add item-level pricing so users can see per-item cost alongside the existing order total without changing backend contracts. 
- Keep styling and behavior consistent with existing MapleXpress components and formatting helpers.

### Description
- Updated the right-hand Shipment Details panel in `components/dashboard/shipments.tsx` to remove `ETA`, `Fragile`, and `Incidents` from order item details and replace the previous package line with `Weight: X kg` (falls back to `N/A`).
- Replaced the ad-hoc `toLocaleString()` created timestamp with a `formatOrderDate` helper (uses `date-fns`) and removed the `Updated` timestamp from the UI so header shows only `Created` and `Payment` metadata.
- Added per-item price display in each order item row using the existing `money()` formatter so item prices use the same `en-CA`/`CAD` formatting as the order total.
- Extended `ClientOrder` typing in `lib/order-service.ts` to include `itemStatus`, `packageDetails.weight`, and `pricing.totalAmount` used by the UI, avoiding `any` casts and keeping compatibility with the existing `OrderItemResponse` shape.

### Testing
- Ran formatting checks and fixes with `pnpm exec prettier --check` and `pnpm exec prettier --write` for the modified files and they passed (`components/dashboard/shipments.tsx`, `lib/order-service.ts`).
- Attempted linting (`pnpm lint` and `pnpm exec eslint ...`) but the environment encountered interactive/ESLint config prompts so automated lint could not complete here (blocked by repo ESLint setup, not changes in this PR).
- Ran TypeScript check with `pnpm exec tsc --noEmit` which surfaced pre-existing, unrelated project-wide typing/test issues; these failures are not caused by the changes in this PR and the UI change is limited to the two modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdba04c96c8329b558196186991bfd)