### PR TITLE
Redirect users to landing page after logout

### DIFF
--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -323,6 +323,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       console.error("Logout error:", error)
     } finally {
       clearSession()
+      if (window.location.pathname !== "/") {
+        window.location.href = "/"
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Ensure that when any logout flow clears the session the user is redirected to the public landing page so they are not left on a protected route.

### Description
- Add a redirect in the shared `logout` implementation in `lib/auth-context.tsx` to set `window.location.href = "/"` after `clearSession()` when not already on the landing page.

### Testing
- Ran `git diff --check` with no issues reported. 
- Ran `pnpm lint` but it was blocked by `next lint` prompting for interactive ESLint setup. 
- Ran `pnpm exec tsc --noEmit` which failed due to pre-existing TypeScript errors in unrelated files, so typecheck errors are not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0479a04b648329b4061873343d7365)