### PR TITLE
Integrate shipments dashboard with customer order APIs

### DIFF
--- a/app/api/orders/my-orders/[shippingOrderId]/route.ts
+++ b/app/api/orders/my-orders/[shippingOrderId]/route.ts
@@ -1,0 +1,26 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
+
+type RouteContext = {
+  params: Promise<{
+    shippingOrderId: string
+  }>
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { shippingOrderId } = await context.params
+
+    return await proxyWithAuthRetry(request, {
+      method: "GET",
+      url: getEndpointUrl(
+        ORDER_SERVICE_URL,
+        `/orders/my-orders/${encodeURIComponent(shippingOrderId)}`,
+      ),
+    })
+  } catch (error) {
+    console.error("Get customer order detail error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/orders/my-orders/route.ts
+++ b/app/api/orders/my-orders/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { ORDER_SERVICE_URL, getEndpointUrl } from "@/lib/config"
+import { proxyWithAuthRetry } from "@/lib/authenticated-proxy"
+
+export async function GET(request: NextRequest) {
+  try {
+    const search = request.nextUrl.search
+
+    return await proxyWithAuthRetry(request, {
+      method: "GET",
+      url: getEndpointUrl(ORDER_SERVICE_URL, `/orders/my-orders${search}`),
+    })
+  } catch (error) {
+    console.error("Get customer orders error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
+  }
+}

--- a/components/dashboard/shipments.tsx
+++ b/components/dashboard/shipments.tsx
@@ -2,9 +2,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
+  getClientOrderDetail,
   getClientOrders,
-  type ClientOrder,
   type ClientOrdersFilters,
+  type CustomerOrderDetailResponse,
+  type CustomerOrderSummaryResponse,
+  type GeneratedDocument,
+  type OrderItem,
 } from "@/lib/order-service";
 import {
   Card,
@@ -26,9 +30,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   CalendarClock,
   Package,
-  Route,
-  Truck,
+  FileText,
   AlertCircle,
+  ExternalLink,
 } from "lucide-react";
 import { format } from "date-fns";
 
@@ -52,7 +56,14 @@ function getSortParams(
 
 function statusBadge(status?: string | null) {
   const value = (status || "").toLowerCase();
-  const success = new Set(["confirmed", "delivered", "partial_complete"]);
+  const success = new Set([
+    "confirmed",
+    "delivered",
+    "partial_complete",
+    "successful",
+    "success",
+    "paid",
+  ]);
   const progress = new Set([
     "label_created",
     "scheduled",
@@ -61,7 +72,7 @@ function statusBadge(status?: string | null) {
     "in_transit",
     "in_progress",
   ]);
-  const warning = new Set(["payment_pending", "end_of_day"]);
+  const warning = new Set(["payment_pending", "pending", "end_of_day"]);
   const danger = new Set([
     "payment_failed",
     "pickup_failed",
@@ -83,7 +94,7 @@ function statusBadge(status?: string | null) {
     tone = "bg-zinc-100 text-zinc-700 border-zinc-200";
 
   const label = status
-    ? status
+    ? value
         .split("_")
         .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
         .join(" ")
@@ -97,22 +108,6 @@ function statusBadge(status?: string | null) {
       {label}
     </Badge>
   );
-}
-
-function summarizeRoute(order: ClientOrder) {
-  const item = order.orderItems?.[0];
-  const pickup = item?.pickup?.address?.city;
-  const dropoff = item?.dropoff?.address?.city;
-  return pickup && dropoff ? `${pickup} → ${dropoff}` : "Route unavailable";
-}
-
-function summarizeTracking(order: ClientOrder) {
-  const ids = order.orderItems
-    ?.map((i) => i.trackingId)
-    .filter(Boolean) as string[];
-  if (!ids?.length) return "No tracking";
-  if (ids.length === 1) return ids[0];
-  return `${ids[0]} +${ids.length - 1}`;
 }
 
 function money(value?: number | null) {
@@ -150,68 +145,140 @@ function itemBucket(
   return "in_progress";
 }
 
+function compactAddress(item: OrderItem, stop: "pickup" | "dropoff") {
+  const address = item[stop]?.address;
+  const city = address?.city || "N/A";
+  const street = address?.streetAddress || "Address unavailable";
+  return `${city} • ${street}`;
+}
+
+function documentLabel(document: GeneratedDocument) {
+  return document.documentName || document.documentType || "Generated document";
+}
+
 export function Shipments() {
   const [sortOption, setSortOption] = useState<SortOption>("newest");
   const [page, setPage] = useState(0);
 
-  const [ordersPage, setOrdersPage] = useState<ClientOrder[]>([]);
+  const [ordersPage, setOrdersPage] = useState<
+    CustomerOrderSummaryResponse[]
+  >([]);
   const [totalElements, setTotalElements] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
+  const [selectedOrderDetail, setSelectedOrderDetail] =
+    useState<CustomerOrderDetailResponse | null>(null);
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
 
   const sortParams = useMemo(() => getSortParams(sortOption), [sortOption]);
 
-  const loadOrders = async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const response = await getClientOrders({
-        page,
-        size: PAGE_SIZE,
-        sortBy: sortParams.sortBy,
-        sortDir: sortParams.sortDir,
-      });
-
-      setOrdersPage(response.orders || []);
-      setTotalElements(response.pagination?.totalElements || 0);
-      setTotalPages(Math.max(1, response.pagination?.totalPages || 1));
-    } catch (err) {
-      console.error("Failed to fetch orders", err);
-      setError("Failed to load shipments. Please try again.");
-      setOrdersPage([]);
-      setTotalElements(0);
-      setTotalPages(0);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   useEffect(() => {
+    let cancelled = false;
+
+    async function loadOrders() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await getClientOrders({
+          page,
+          size: PAGE_SIZE,
+          sortBy: sortParams.sortBy,
+          sortDir: sortParams.sortDir,
+        });
+        const nonDraftOrders = (response.orders || []).filter(
+          (order) => order.orderStatus?.toLowerCase() !== "draft",
+        );
+
+        if (cancelled) return;
+        setOrdersPage(nonDraftOrders);
+        setTotalElements(response.pagination?.totalElements || 0);
+        setTotalPages(response.pagination?.totalPages || 0);
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to fetch orders", err);
+        setError("Failed to load shipments. Please try again.");
+        setOrdersPage([]);
+        setTotalElements(0);
+        setTotalPages(0);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
     loadOrders();
+
+    return () => {
+      cancelled = true;
+    };
   }, [page, sortParams]);
 
   useEffect(() => {
     if (!ordersPage.length) {
       setSelectedOrderId(null);
+      setSelectedOrderDetail(null);
       return;
     }
 
     const exists =
       selectedOrderId &&
-      ordersPage.some((o) => o.shippingOrderId === selectedOrderId);
+      ordersPage.some((order) => order.shippingOrderId === selectedOrderId);
     if (!exists) {
       setSelectedOrderId(ordersPage[0].shippingOrderId);
     }
-  }, [ordersPage, selectedOrderId, page]);
+  }, [ordersPage, selectedOrderId]);
 
-  const selectedOrder = useMemo(
-    () => ordersPage.find((o) => o.shippingOrderId === selectedOrderId) || null,
+  useEffect(() => {
+    if (!selectedOrderId) {
+      setSelectedOrderDetail(null);
+      setDetailError(null);
+      setIsDetailLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const orderId = selectedOrderId;
+
+    async function loadOrderDetail() {
+      setIsDetailLoading(true);
+      setDetailError(null);
+      setSelectedOrderDetail(null);
+
+      try {
+        const detail = await getClientOrderDetail(orderId);
+        if (cancelled) return;
+        setSelectedOrderDetail({
+          shippingOrder: detail.shippingOrder ?? null,
+          documents: detail.documents ?? [],
+        });
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to fetch order detail", err);
+        setDetailError("Failed to load this shipment. Please try again.");
+      } finally {
+        if (!cancelled) setIsDetailLoading(false);
+      }
+    }
+
+    loadOrderDetail();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedOrderId]);
+
+  const selectedSummary = useMemo(
+    () =>
+      ordersPage.find((order) => order.shippingOrderId === selectedOrderId) ||
+      null,
     [ordersPage, selectedOrderId],
   );
+  const selectedOrder = selectedOrderDetail?.shippingOrder ?? null;
+  const documents = selectedOrderDetail?.documents ?? [];
 
   const itemProgress = useMemo(() => {
     if (!selectedOrder?.orderItems?.length)
@@ -281,7 +348,7 @@ export function Shipments() {
               </div>
             ) : ordersPage.length === 0 ? (
               <div className="flex-1 px-4 py-10 text-center text-xs text-muted-foreground flex items-center justify-center">
-                No orders found for the current page.
+                No shipments found yet.
               </div>
             ) : (
               <div className="divide-y border-y flex-1">
@@ -298,7 +365,7 @@ export function Shipments() {
                           {order.shippingOrderId}
                         </p>
                         <p className="text-xs font-semibold">
-                          {money(order.aggregatedPricing?.totalAmount)}
+                          {money(order.amount)}
                         </p>
                       </div>
                       <div className="mt-1 flex items-center gap-2">
@@ -306,15 +373,12 @@ export function Shipments() {
                       </div>
                       <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
                         <span className="inline-flex items-center gap-1">
-                          <Route className="h-3 w-3" /> {summarizeRoute(order)}
-                        </span>
-                        <span className="inline-flex items-center gap-1">
                           <CalendarClock className="h-3 w-3" />{" "}
-                          {new Date(order.createdAt).toLocaleDateString()}
+                          {formatOrderDate(order.createdAt)}
                         </span>
                         <span className="inline-flex items-center gap-1">
                           <Package className="h-3 w-3" />{" "}
-                          {order.orderItems?.length || 0} items
+                          {order.numberOfOrderItems ?? 0} items
                         </span>
                       </div>
                     </button>
@@ -325,19 +389,21 @@ export function Shipments() {
 
             <div className="flex items-center justify-between px-3 pt-2 mt-auto border-t">
               <p className="text-[11px] text-muted-foreground">
-                Page {page + 1} / {Math.max(totalPages, 1)}
+                Page {totalPages === 0 ? 0 : page + 1} / {totalPages || 0}
               </p>
               <div className="flex gap-1">
                 <button
                   className="text-xs border rounded px-2 py-1 disabled:opacity-50"
                   disabled={page <= 0 || isLoading}
-                  onClick={() => setPage((prev) => prev - 1)}
+                  onClick={() => setPage((prev) => Math.max(0, prev - 1))}
                 >
                   Prev
                 </button>
                 <button
                   className="text-xs border rounded px-2 py-1 disabled:opacity-50"
-                  disabled={isLoading || page + 1 >= totalPages}
+                  disabled={
+                    isLoading || totalPages === 0 || page + 1 >= totalPages
+                  }
                   onClick={() => setPage((prev) => prev + 1)}
                 >
                   Next
@@ -349,9 +415,26 @@ export function Shipments() {
 
         <Card className="lg:col-span-3">
           <CardContent className="p-3 space-y-3">
-            {!selectedOrder ? (
+            {isDetailLoading ? (
+              <div className="min-h-[460px] space-y-3">
+                <div className="border rounded-md p-3 space-y-2">
+                  <Skeleton className="h-6 w-48" />
+                  <Skeleton className="h-4 w-full" />
+                  <Skeleton className="h-4 w-3/4" />
+                </div>
+                <Skeleton className="h-28 w-full" />
+                <Skeleton className="h-28 w-full" />
+              </div>
+            ) : detailError ? (
+              <Alert variant="destructive" className="py-2">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription className="text-sm">{detailError}</AlertDescription>
+              </Alert>
+            ) : !selectedOrder ? (
               <div className="h-full min-h-[460px] flex items-center justify-center text-sm text-muted-foreground">
-                Select a shipping order to view details.
+                {ordersPage.length
+                  ? "Select a shipping order to view details."
+                  : "No shipment details to display."}
               </div>
             ) : (
               <>
@@ -364,14 +447,20 @@ export function Shipments() {
                       {statusBadge(selectedOrder.orderStatus)}
                     </div>
                     <p className="text-lg font-semibold">
-                      {money(selectedOrder.aggregatedPricing?.totalAmount)}
+                      {money(
+                        selectedOrder.aggregatedPricing?.totalAmount ??
+                          selectedSummary?.amount,
+                      )}
                     </p>
                   </div>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-muted-foreground">
                     <div>
                       Created: {formatOrderDate(selectedOrder.createdAt)}
                     </div>
-                    <div>Payment: {selectedOrder.paymentStatus || "N/A"}</div>
+                    <div className="flex items-center gap-2">
+                      <span>Payment:</span>
+                      {statusBadge(selectedOrder.paymentStatus)}
+                    </div>
                   </div>
                   <div className="flex flex-wrap items-center gap-2 text-xs">
                     <Badge variant="outline" className="h-6">
@@ -416,21 +505,13 @@ export function Shipments() {
                               <p className="font-medium text-foreground">
                                 Pickup
                               </p>
-                              <p>
-                                {item.pickup?.address?.city || "N/A"} •{" "}
-                                {item.pickup?.address?.streetAddress ||
-                                  "Address unavailable"}
-                              </p>
+                              <p>{compactAddress(item, "pickup")}</p>
                             </div>
                             <div>
                               <p className="font-medium text-foreground">
                                 Dropoff
                               </p>
-                              <p>
-                                {item.dropoff?.address?.city || "N/A"} •{" "}
-                                {item.dropoff?.address?.streetAddress ||
-                                  "Address unavailable"}
-                              </p>
+                              <p>{compactAddress(item, "dropoff")}</p>
                             </div>
                             <div>
                               Weight:{" "}
@@ -445,6 +526,50 @@ export function Shipments() {
                   ) : (
                     <div className="text-xs text-muted-foreground border rounded-md p-3">
                       No order items available.
+                    </div>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <h3 className="text-sm font-semibold">Documents</h3>
+                  {documents.length ? (
+                    <div className="divide-y border rounded-md">
+                      {documents.map((document, idx) => (
+                        <div
+                          key={document.s3Key || document.presignedUrl || idx}
+                          className="p-2.5 flex items-center justify-between gap-3"
+                        >
+                          <div className="min-w-0 flex items-center gap-2">
+                            <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0">
+                              <p className="text-sm font-medium truncate">
+                                {documentLabel(document)}
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                {document.documentType || "Document"}
+                              </p>
+                            </div>
+                          </div>
+                          {document.presignedUrl ? (
+                            <a
+                              className="inline-flex items-center gap-1 text-xs border rounded px-2 py-1 hover:bg-muted"
+                              href={document.presignedUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              Open <ExternalLink className="h-3 w-3" />
+                            </a>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">
+                              Unavailable
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-xs text-muted-foreground border rounded-md p-3">
+                      No documents available for this order.
                     </div>
                   )}
                 </div>

--- a/lib/order-service.ts
+++ b/lib/order-service.ts
@@ -1,6 +1,6 @@
 import type {
-  ShippingOrder,
-  Address,
+  ShippingOrder as DraftShippingOrder,
+  Address as DraftAddress,
 } from "@/components/ship-now/ship-now-form";
 
 import { apiFetch } from "@/lib/client-api";
@@ -94,39 +94,133 @@ export interface OrderItemResponse {
   specialIncidents: any[];
 }
 
-export interface ClientOrder {
-  shippingOrderId: string;
-  orderStatus: string;
-  paymentStatus: string;
-  priorityDelivery: boolean;
-  createdAt: string;
-  updatedAt?: string;
-  aggregatedPricing?: {
-    totalAmount?: number;
-  };
-  orderItems: Array<{
-    trackingId?: string | null;
-    itemStatus?: string | null;
-    pickup?: {
-      address?: {
-        city?: string;
-        streetAddress?: string;
-      };
-    };
-    dropoff?: {
-      address?: {
-        city?: string;
-        streetAddress?: string;
-      };
-    };
-    packageDetails?: {
-      weight?: number | null;
-    };
-    pricing?: {
-      totalAmount?: number | null;
-    };
-  }>;
+export interface Tax {
+  amount: number;
+  taxType: string;
 }
+
+export interface Pricing {
+  basePrice?: number | null;
+  distanceCharge?: number | null;
+  weightCharge?: number | null;
+  dimensionalWeightCharge?: number | null;
+  prioritySurcharge?: number | null;
+  taxes?: Tax[];
+  discount?: number | null;
+  totalAmount?: number | null;
+  pricingId?: string | null;
+}
+
+export interface Address {
+  fullName?: string | null;
+  company?: string | null;
+  streetAddress?: string | null;
+  addressLine2?: string | null;
+  city?: string | null;
+  province?: string | null;
+  postalCode?: string | null;
+  country?: string | null;
+  phoneNumber?: string | null;
+  deliveryInstructions?: string | null;
+}
+
+export interface Coordinates {
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+export interface Stop {
+  address?: Address | null;
+  coordinates?: Coordinates | null;
+  time?: string | null;
+  notes?: string | null;
+  images?: unknown[];
+}
+
+export interface OrderItem {
+  orderItemId?: string | null;
+  trackingId?: string | null;
+  pickup?: Stop | null;
+  dropoff?: Stop | null;
+  distanceToDelivery?: number | null;
+  packageDetails?: {
+    weight?: number | null;
+    dimensions?: {
+      length?: number | null;
+      width?: number | null;
+      height?: number | null;
+    } | null;
+    type?: string | null;
+    value?: number | null;
+    images?: unknown[];
+  } | null;
+  pricing?: Pricing | null;
+  itemStatus?: string | null;
+  assignedDriverId?: string | null;
+  isFragile?: boolean | null;
+  estimatedDeliveryTime?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  specialIncidents?: unknown[];
+}
+
+export interface ShippingOrder {
+  shippingOrderId: string;
+  userId?: string | null;
+  clientUserId?: string | null;
+  clientType?: string | null;
+  customerContact?: {
+    name?: string | null;
+    phone?: string | null;
+    email?: string | null;
+  } | null;
+  priorityDelivery?: boolean | null;
+  orderStatus?: string | null;
+  assignedDriverId?: string | null;
+  paymentStatus?: string | null;
+  paymentId?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  aggregatedPricing?: Pricing | null;
+  orderItems?: OrderItem[];
+}
+
+export interface GeneratedDocument {
+  documentType?: string | null;
+  documentName?: string | null;
+  s3Key?: string | null;
+  presignedUrl?: string | null;
+}
+
+export interface CustomerOrderDetailResponse {
+  shippingOrder?: ShippingOrder | null;
+  documents?: GeneratedDocument[];
+}
+
+export interface CustomerOrderSummaryResponse {
+  shippingOrderId: string;
+  createdAt?: string | null;
+  orderStatus?: string | null;
+  amount?: number | null;
+  numberOfOrderItems?: number | null;
+}
+
+export interface PaginationMetadata {
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  sortBy: string;
+  sortDir: "asc" | "desc";
+}
+
+export interface PagedCustomerOrderSummaryResponse {
+  orders: CustomerOrderSummaryResponse[];
+  pagination: PaginationMetadata;
+}
+
+export type ClientOrdersResponse = PagedCustomerOrderSummaryResponse;
+export type ClientOrder = CustomerOrderSummaryResponse;
 
 export interface ClientOrdersFilters {
   orderStatus?: string;
@@ -137,18 +231,6 @@ export interface ClientOrdersFilters {
   size?: number;
   sortBy?: string;
   sortDir?: "asc" | "desc";
-}
-
-interface ClientOrdersResponse {
-  orders: ClientOrder[];
-  pagination: {
-    page: number;
-    size: number;
-    totalElements: number;
-    totalPages: number;
-    sortBy: string;
-    sortDir: "asc" | "desc";
-  };
 }
 
 interface OrderRequestItem {
@@ -196,7 +278,7 @@ interface AddressResponse {
 
 // Function to create or update a draft order
 export async function createDraftOrder(
-  order: ShippingOrder,
+  order: DraftShippingOrder,
   userId: string,
   priorityDelivery = false,
   existingOrderId?: string,
@@ -244,7 +326,7 @@ export async function createDraftOrder(
 
 // Helper function to format the order request
 function formatOrderRequest(
-  order: ShippingOrder,
+  order: DraftShippingOrder,
   userId: string,
   priorityDelivery: boolean,
   existingOrderId?: string,
@@ -312,7 +394,7 @@ export async function updateOrder(payload: OrderRequest) {
 }
 
 // Helper function to format address
-function formatAddress(address: Address | null) {
+function formatAddress(address: DraftAddress | null) {
   if (!address) return null;
 
   return {
@@ -364,7 +446,7 @@ export async function getClientOrders(
   params.set("sortBy", filters.sortBy ?? "createdAt");
   params.set("sortDir", filters.sortDir ?? "desc");
 
-  const response = await apiFetch(`/api/orders?${params.toString()}`, {
+  const response = await apiFetch(`/api/orders/my-orders?${params.toString()}`, {
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
@@ -378,21 +460,33 @@ export async function getClientOrders(
   const data = await response.json();
 
   if (Array.isArray(data)) {
+    const orders = data.filter(
+      (order: CustomerOrderSummaryResponse) =>
+        order?.orderStatus?.toLowerCase() !== "draft",
+    );
+
     return {
-      orders: data,
+      orders,
       pagination: {
         page: filters.page ?? 0,
         size: filters.size ?? 10,
-        totalElements: data.length,
-        totalPages: data.length ? 1 : 0,
+        totalElements: orders.length,
+        totalPages: orders.length ? 1 : 0,
         sortBy: filters.sortBy ?? "createdAt",
         sortDir: filters.sortDir ?? "desc",
       },
     };
   }
 
+  const orders = Array.isArray(data?.orders)
+    ? data.orders.filter(
+        (order: CustomerOrderSummaryResponse) =>
+          order?.orderStatus?.toLowerCase() !== "draft",
+      )
+    : [];
+
   return {
-    orders: data?.orders ?? [],
+    orders,
     pagination: {
       page: data?.pagination?.page ?? 0,
       size: data?.pagination?.size ?? filters.size ?? 10,
@@ -401,5 +495,28 @@ export async function getClientOrders(
       sortBy: data?.pagination?.sortBy ?? "createdAt",
       sortDir: data?.pagination?.sortDir === "asc" ? "asc" : "desc",
     },
+  };
+}
+
+export async function getClientOrderDetail(
+  shippingOrderId: string,
+): Promise<CustomerOrderDetailResponse> {
+  const response = await apiFetch(
+    `/api/orders/my-orders/${encodeURIComponent(shippingOrderId)}`,
+    {
+      headers: {
+        Accept: "application/json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch order details: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return {
+    shippingOrder: data?.shippingOrder ?? null,
+    documents: Array.isArray(data?.documents) ? data.documents : [],
   };
 }


### PR DESCRIPTION
### Motivation
- Replace the Shipments page data integration to use the new customer order APIs (`/orders/my-orders`) while preserving existing server-side auth/refresh behavior.
- Keep tokens and refresh logic on the server proxy layer and avoid duplicating the `/ordermanagement` context path already present in `ORDER_SERVICE_URL`.
- Provide practical, focused TypeScript types for the new response shapes and adapt the minimal UI rendering so the page continues to work with the new responses.

### Description
- Add server-side authenticated proxy routes for customer order summaries and detail at `app/api/orders/my-orders` and `app/api/orders/my-orders/[shippingOrderId]`, using `getEndpointUrl(ORDER_SERVICE_URL, ...)` and `proxyWithAuthRetry` so auth cookies/tokens remain server-side.
- Add concise types and nullable-safe models in `lib/order-service.ts` (summary/detail, `ShippingOrder`, `OrderItem`, `Address`/`Stop`, `Pricing`/`Tax`, `GeneratedDocument`, `PaginationMetadata`) and extend the client-facing service helpers.
- Update service helpers: `getClientOrders` now calls `/api/orders/my-orders` with backend pagination params (page,size=10,sortBy,sortDir), filters out `draft` orders defensively, and `getClientOrderDetail` fetches `/api/orders/my-orders/{shippingOrderId}` and returns `shippingOrder` + `documents`.
- Refactor `components/dashboard/shipments.tsx` to use the new service APIs: backend-driven pagination (page size 10), auto-select first order on load, separate list/detail loading and error states, fetch detail on selection, render summary fields (shippingOrderId, createdAt, orderStatus, amount, numberOfOrderItems), render order items using `item.pricing.totalAmount` and compact addresses, and show generated documents with `presignedUrl` links kept only in page state.

### Testing
- Ran `git diff --check` which reported no issues for the changed files. (passed)
- Ran `npx tsc --noEmit` which surfaced pre-existing TypeScript errors in unrelated areas of the repo (for example `app/forgotpassword/page.tsx`, address typings, and test globals); these are not introduced by this PR. (blocked/failed due to unrelated repo errors)
- Ran `npm run lint` which was blocked by an interactive Next.js ESLint setup prompt in this environment and could not complete non-interactively. (blocked)
- Ran `npm run build` which failed in this environment due to font fetch/network failures for `next/font` (Google Fonts) but the build errors are environment/network related and not caused by the API integration changes. (blocked)

Files changed: `components/dashboard/shipments.tsx`, `lib/order-service.ts`, `app/api/orders/my-orders/route.ts`, `app/api/orders/my-orders/[shippingOrderId]/route.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06454f502083299b00b7bd6d778763)