### PR TITLE
Add deep-link support to Shipments (orderId query param)

### DIFF
--- a/components/dashboard/shipments.tsx
+++ b/components/dashboard/shipments.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   getClientOrderDetail,
   getClientOrders,
@@ -157,6 +158,10 @@ function documentLabel(document: GeneratedDocument) {
 }
 
 export function Shipments() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const orderIdParam = searchParams.get("orderId")?.trim() || null;
+
   const [sortOption, setSortOption] = useState<SortOption>("newest");
   const [page, setPage] = useState(0);
 
@@ -218,11 +223,21 @@ export function Shipments() {
   }, [page, sortParams]);
 
   useEffect(() => {
+    if (orderIdParam) {
+      setSelectedOrderId(orderIdParam);
+    }
+  }, [orderIdParam]);
+
+  useEffect(() => {
     if (!ordersPage.length) {
-      setSelectedOrderId(null);
-      setSelectedOrderDetail(null);
+      if (!orderIdParam) {
+        setSelectedOrderId(null);
+        setSelectedOrderDetail(null);
+      }
       return;
     }
+
+    if (orderIdParam) return;
 
     const exists =
       selectedOrderId &&
@@ -230,7 +245,7 @@ export function Shipments() {
     if (!exists) {
       setSelectedOrderId(ordersPage[0].shippingOrderId);
     }
-  }, [ordersPage, selectedOrderId]);
+  }, [ordersPage, selectedOrderId, orderIdParam]);
 
   useEffect(() => {
     if (!selectedOrderId) {
@@ -258,7 +273,9 @@ export function Shipments() {
       } catch (err) {
         if (cancelled) return;
         console.error("Failed to fetch order detail", err);
-        setDetailError("Failed to load this shipment. Please try again.");
+        setDetailError(
+          "We could not load this order. Please check the link or try again.",
+        );
       } finally {
         if (!cancelled) setIsDetailLoading(false);
       }
@@ -270,6 +287,15 @@ export function Shipments() {
       cancelled = true;
     };
   }, [selectedOrderId]);
+
+  const handleSelectOrder = (shippingOrderId: string) => {
+    setSelectedOrderId(shippingOrderId);
+
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("section", "shipments");
+    params.set("orderId", shippingOrderId);
+    router.push(`/dashboard?${params.toString()}`);
+  };
 
   const selectedSummary = useMemo(
     () =>
@@ -358,7 +384,7 @@ export function Shipments() {
                     <button
                       key={order.shippingOrderId}
                       className={`w-full text-left px-3 py-2.5 hover:bg-muted/30 ${selected ? "bg-muted/60" : ""}`}
-                      onClick={() => setSelectedOrderId(order.shippingOrderId)}
+                      onClick={() => handleSelectOrder(order.shippingOrderId)}
                     >
                       <div className="flex items-center justify-between gap-2">
                         <p className="text-sm font-semibold truncate">


### PR DESCRIPTION
### Motivation

- Allow customers to open `/dashboard?section=shipments&orderId=<shippingOrderId>` from emails so a specific shipping order is shown directly in the Shipments detail panel.

### Description

- Read `orderId` from URL search params using `useSearchParams` and prioritize it as the selected order when present, without depending on the current paginated sidebar page.
- Keep the paginated sidebar list fetch unchanged and continue to fetch order details via the existing `getClientOrderDetail` helper which calls `/api/orders/my-orders/{shippingOrderId}` (proxied to `${ORDER_SERVICE_URL}/orders/my-orders/${orderId}`).
- Update the URL query params to `/dashboard?section=shipments&orderId=<id>` when a user selects an order from the sidebar using `router.push`, preserving client-side navigation.
- Add a clear detail error message: `We could not load this order. Please check the link or try again.` and ensure the existing selected-state/highlighting behavior remains when the selected order appears in the current page.
- Files changed: `components/dashboard/shipments.tsx` only; no other dashboard sections or APIs were refactored.

### Testing

- Ran `git diff --check` which passed without whitespace errors.
- Ran `npm run lint` but it did not complete because `next lint` prompted interactively to configure ESLint (blocked the automated run).
- Ran type-check with `npx tsc --noEmit` which reported unrelated existing TypeScript errors outside this change (so type-check for the project did not fully pass but the edited file is TypeScript-correct in context).
- Ran `npm run build` which failed due to external font fetch errors during Next.js production build (environment issue unrelated to the code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a064a2fee988329a4c7c698a1a54601)